### PR TITLE
feat: シードデータの作成 (Issue #2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@prisma/client": "^5.20.0",
+        "bcrypt": "^6.0.0",
         "next": "^14.2.0",
         "next-auth": "^4.24.0",
         "react": "^18.3.0",
@@ -23,6 +24,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
+        "@types/bcrypt": "^6.0.0",
         "@types/node": "^20.16.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -39,6 +41,7 @@
         "msw": "^2.12.7",
         "prettier": "^3.7.4",
         "prisma": "^5.20.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^4.0.16"
       }
@@ -2466,6 +2469,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3531,6 +3544,20 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/bidi-js": {
@@ -7084,6 +7111,26 @@
         }
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -8884,6 +8931,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,13 @@
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"
   },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@prisma/client": "^5.20.0",
+    "bcrypt": "^6.0.0",
     "next": "^14.2.0",
     "next-auth": "^4.24.0",
     "react": "^18.3.0",
@@ -36,6 +40,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
+    "@types/bcrypt": "^6.0.0",
     "@types/node": "^20.16.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
@@ -52,6 +57,7 @@
     "msw": "^2.12.7",
     "prettier": "^3.7.4",
     "prisma": "^5.20.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.6.0",
     "vitest": "^4.0.16"
   }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,292 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('🌱 Starting seed...');
+
+  // パスワードのハッシュ化
+  const hashedPassword = await bcrypt.hash('password123', 10);
+
+  // 営業担当者データの作成
+  console.log('📝 Creating sales...');
+
+  // 上長
+  const manager = await prisma.sales.upsert({
+    where: { email: 'manager@example.com' },
+    update: {},
+    create: {
+      salesName: '山田太郎',
+      email: 'manager@example.com',
+      password: hashedPassword,
+      department: '営業一部',
+      role: '上長',
+    },
+  });
+
+  // 一般営業1
+  const sales1 = await prisma.sales.upsert({
+    where: { email: 'sales1@example.com' },
+    update: {},
+    create: {
+      salesName: '佐藤花子',
+      email: 'sales1@example.com',
+      password: hashedPassword,
+      department: '営業一部',
+      role: '一般',
+      managerId: manager.salesId,
+    },
+  });
+
+  // 一般営業2
+  const sales2 = await prisma.sales.upsert({
+    where: { email: 'sales2@example.com' },
+    update: {},
+    create: {
+      salesName: '鈴木一郎',
+      email: 'sales2@example.com',
+      password: hashedPassword,
+      department: '営業一部',
+      role: '一般',
+      managerId: manager.salesId,
+    },
+  });
+
+  console.log(`✅ Created ${3} sales users`);
+
+  // 顧客データの作成
+  console.log('📝 Creating customers...');
+
+  const customers = await Promise.all([
+    prisma.customer.upsert({
+      where: { customerId: 1 },
+      update: {},
+      create: {
+        customerName: '田中次郎',
+        companyName: '株式会社テクノロジー',
+        industry: 'IT',
+        phone: '03-1234-5678',
+        email: 'tanaka@technology.co.jp',
+        address: '東京都渋谷区渋谷1-1-1',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 2 },
+      update: {},
+      create: {
+        customerName: '高橋美咲',
+        companyName: '山田商事株式会社',
+        industry: '卸売業',
+        phone: '06-2345-6789',
+        email: 'takahashi@yamada-trading.co.jp',
+        address: '大阪府大阪市北区梅田2-2-2',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 3 },
+      update: {},
+      create: {
+        customerName: '伊藤健太',
+        companyName: '株式会社グローバル商社',
+        industry: '商社',
+        phone: '052-3456-7890',
+        email: 'ito@global-trading.co.jp',
+        address: '愛知県名古屋市中区栄3-3-3',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 4 },
+      update: {},
+      create: {
+        customerName: '渡辺優子',
+        companyName: '渡辺工業株式会社',
+        industry: '製造業',
+        phone: '045-4567-8901',
+        email: 'watanabe@watanabe-industry.co.jp',
+        address: '神奈川県横浜市西区みなとみらい4-4-4',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 5 },
+      update: {},
+      create: {
+        customerName: '中村大輔',
+        companyName: '株式会社フューチャーシステム',
+        industry: 'IT',
+        phone: '092-5678-9012',
+        email: 'nakamura@future-system.co.jp',
+        address: '福岡県福岡市博多区博多駅前5-5-5',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 6 },
+      update: {},
+      create: {
+        customerName: '小林真由美',
+        companyName: '小林リテール株式会社',
+        industry: '小売業',
+        phone: '011-6789-0123',
+        email: 'kobayashi@kobayashi-retail.co.jp',
+        address: '北海道札幌市中央区大通6-6-6',
+      },
+    }),
+  ]);
+
+  console.log(`✅ Created ${customers.length} customers`);
+
+  // 日報データの作成
+  console.log('📝 Creating daily reports...');
+
+  // 下書き状態の日報
+  const report1 = await prisma.dailyReport.create({
+    data: {
+      salesId: sales1.salesId,
+      reportDate: new Date('2024-01-05'),
+      problem: '新規顧客の開拓が思うように進んでいない。',
+      plan: '明日は既存顧客へのフォローアップを中心に行う。',
+      status: '下書き',
+    },
+  });
+
+  // 提出済み状態の日報
+  const report2 = await prisma.dailyReport.create({
+    data: {
+      salesId: sales1.salesId,
+      reportDate: new Date('2024-01-04'),
+      problem: '特になし',
+      plan: '明日は新規顧客3社を訪問予定。',
+      status: '提出済み',
+      submittedAt: new Date('2024-01-04T18:00:00'),
+    },
+  });
+
+  // 承認済み状態の日報
+  const report3 = await prisma.dailyReport.create({
+    data: {
+      salesId: sales2.salesId,
+      reportDate: new Date('2024-01-03'),
+      problem: '特になし',
+      plan: '明日は既存顧客との契約更新交渉を行う。',
+      status: '承認済み',
+      submittedAt: new Date('2024-01-03T18:00:00'),
+      approvedAt: new Date('2024-01-03T19:30:00'),
+      approvedBy: manager.salesId,
+    },
+  });
+
+  // 差し戻し状態の日報
+  const report4 = await prisma.dailyReport.create({
+    data: {
+      salesId: sales2.salesId,
+      reportDate: new Date('2024-01-02'),
+      problem: '訪問記録の詳細が不足しています。',
+      plan: '明日は顧客訪問を予定。',
+      status: '差し戻し',
+      submittedAt: new Date('2024-01-02T18:00:00'),
+    },
+  });
+
+  console.log(`✅ Created ${4} daily reports`);
+
+  // 訪問記録データの作成
+  console.log('📝 Creating visits...');
+
+  await prisma.visit.createMany({
+    data: [
+      {
+        reportId: report2.reportId,
+        customerId: customers[0].customerId,
+        visitContent:
+          '新製品のプレゼンテーションを実施。好感触を得た。次回は具体的な提案を持参する予定。',
+        visitTime: new Date('2024-01-04T10:00:00'),
+      },
+      {
+        reportId: report2.reportId,
+        customerId: customers[1].customerId,
+        visitContent:
+          '契約更新の打ち合わせ。価格面で調整が必要。来週再訪問予定。',
+        visitTime: new Date('2024-01-04T14:00:00'),
+      },
+      {
+        reportId: report3.reportId,
+        customerId: customers[2].customerId,
+        visitContent:
+          '四半期の業績報告と次期の提案を実施。追加発注の可能性あり。',
+        visitTime: new Date('2024-01-03T11:00:00'),
+      },
+      {
+        reportId: report3.reportId,
+        customerId: customers[3].customerId,
+        visitContent: '新規案件のヒアリング。要件定義書を次回までに作成する。',
+        visitTime: new Date('2024-01-03T15:30:00'),
+      },
+      {
+        reportId: report4.reportId,
+        customerId: customers[4].customerId,
+        visitContent: '定例訪問。',
+        visitTime: new Date('2024-01-02T10:00:00'),
+      },
+    ],
+  });
+
+  console.log(`✅ Created ${5} visits`);
+
+  // コメントデータの作成
+  console.log('📝 Creating comments...');
+
+  await prisma.comment.createMany({
+    data: [
+      {
+        reportId: report2.reportId,
+        salesId: manager.salesId,
+        commentContent:
+          '訪問記録が詳細で良いです。次回の提案に期待しています。',
+      },
+      {
+        reportId: report3.reportId,
+        salesId: manager.salesId,
+        commentContent:
+          '素晴らしい成果です。引き続き顧客との関係強化をお願いします。',
+      },
+      {
+        reportId: report4.reportId,
+        salesId: manager.salesId,
+        commentContent:
+          '訪問内容の詳細を追記してください。どのような話をしたのか、顧客の反応はどうだったのかを記載してください。',
+      },
+      {
+        reportId: report4.reportId,
+        salesId: sales2.salesId,
+        commentContent: '承知しました。訪問内容を詳細に記載して再提出します。',
+      },
+    ],
+  });
+
+  console.log(`✅ Created ${4} comments`);
+
+  console.log('');
+  console.log('🎉 Seed completed successfully!');
+  console.log('');
+  console.log('📊 Summary:');
+  console.log('  - Sales users: 3 (1 manager, 2 sales)');
+  console.log('  - Customers: 6');
+  console.log('  - Daily reports: 4 (下書き, 提出済み, 承認済み, 差し戻し)');
+  console.log('  - Visits: 5');
+  console.log('  - Comments: 4');
+  console.log('');
+  console.log('🔐 Test user credentials:');
+  console.log('  Manager: manager@example.com / password123');
+  console.log('  Sales 1: sales1@example.com / password123');
+  console.log('  Sales 2: sales2@example.com / password123');
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Error seeding database:');
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
Issue #2の実装: 開発・テスト用のシードデータを作成

- bcryptを使用したパスワードハッシュ化の実装
- Prisma seedスクリプトの作成
- 包括的なテストデータの生成:
  - 3名の営業ユーザー（上長1名、一般営業2名）
  - 6社の顧客データ
  - 4件の日報（全ステータス: 下書き、提出済み、承認済み、差し戻し）
  - 5件の訪問記録
  - 4件のコメント

## Test plan
- [x] bcryptパッケージのインストール確認
- [x] seed.tsファイルの作成
- [x] package.jsonにseedスクリプト追加
- [x] `npx prisma db seed`の実行成功確認
- [x] シードデータの投入確認（3 sales, 6 customers, 4 reports, 5 visits, 4 comments）
- [x] テストユーザーの認証情報確認

## Notes
テストユーザーの認証情報:
- Manager: manager@example.com / password123
- Sales 1: sales1@example.com / password123
- Sales 2: sales2@example.com / password123

🤖 Generated with [Claude Code](https://claude.com/claude-code)