### PR TITLE
feat: Issue #2 シードデータの作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@prisma/client": "^5.20.0",
+        "bcryptjs": "^3.0.3",
         "next": "^14.2.0",
         "next-auth": "^4.24.0",
         "react": "^18.3.0",
@@ -23,6 +24,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20.16.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -39,6 +41,7 @@
         "msw": "^2.12.7",
         "prettier": "^3.7.4",
         "prisma": "^5.20.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^4.0.16"
       }
@@ -2466,6 +2469,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3531,6 +3541,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/bidi-js": {
@@ -8884,6 +8903,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "prepare": "husky"
+    "prepare": "husky",
+    "seed": "npx prisma db seed"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
     "@prisma/client": "^5.20.0",
+    "bcryptjs": "^3.0.3",
     "next": "^14.2.0",
     "next-auth": "^4.24.0",
     "react": "^18.3.0",
@@ -31,11 +33,15 @@
     "react-hook-form": "^7.53.0",
     "zod": "^3.23.0"
   },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20.16.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
@@ -52,6 +58,7 @@
     "msw": "^2.12.7",
     "prettier": "^3.7.4",
     "prisma": "^5.20.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.6.0",
     "vitest": "^4.0.16"
   }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,311 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('Start seeding...');
+
+  // パスワードをハッシュ化
+  const hashedPassword = await bcrypt.hash('password123', 10);
+
+  // 営業担当者データの作成（上長1名、一般営業2名）
+  const manager = await prisma.sales.upsert({
+    where: { email: 'manager@example.com' },
+    update: {},
+    create: {
+      salesName: '山田 太郎',
+      email: 'manager@example.com',
+      password: hashedPassword,
+      department: '営業部',
+      role: '上長',
+    },
+  });
+  console.log(`Created manager: ${manager.salesName}`);
+
+  const sales1 = await prisma.sales.upsert({
+    where: { email: 'sales1@example.com' },
+    update: {},
+    create: {
+      salesName: '鈴木 一郎',
+      email: 'sales1@example.com',
+      password: hashedPassword,
+      department: '営業部',
+      role: '一般',
+      managerId: manager.salesId,
+    },
+  });
+  console.log(`Created sales: ${sales1.salesName}`);
+
+  const sales2 = await prisma.sales.upsert({
+    where: { email: 'sales2@example.com' },
+    update: {},
+    create: {
+      salesName: '佐藤 花子',
+      email: 'sales2@example.com',
+      password: hashedPassword,
+      department: '営業部',
+      role: '一般',
+      managerId: manager.salesId,
+    },
+  });
+  console.log(`Created sales: ${sales2.salesName}`);
+
+  // 顧客データの作成（5件以上）
+  const customers = await Promise.all([
+    prisma.customer.upsert({
+      where: { customerId: 1 },
+      update: {},
+      create: {
+        customerName: '田中 健太',
+        companyName: '株式会社ABC商事',
+        industry: '商社',
+        phone: '03-1234-5678',
+        email: 'tanaka@abc-shoji.example.com',
+        address: '東京都千代田区丸の内1-1-1',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 2 },
+      update: {},
+      create: {
+        customerName: '高橋 美咲',
+        companyName: 'XYZ製造株式会社',
+        industry: '製造業',
+        phone: '06-9876-5432',
+        email: 'takahashi@xyz-mfg.example.com',
+        address: '大阪府大阪市北区梅田2-2-2',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 3 },
+      update: {},
+      create: {
+        customerName: '伊藤 大輔',
+        companyName: 'テックソリューション株式会社',
+        industry: 'IT',
+        phone: '045-111-2222',
+        email: 'ito@techsol.example.com',
+        address: '神奈川県横浜市西区みなとみらい3-3-3',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 4 },
+      update: {},
+      create: {
+        customerName: '渡辺 さくら',
+        companyName: 'グローバル物流株式会社',
+        industry: '物流',
+        phone: '052-333-4444',
+        email: 'watanabe@global-logistics.example.com',
+        address: '愛知県名古屋市中区栄4-4-4',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 5 },
+      update: {},
+      create: {
+        customerName: '中村 翔太',
+        companyName: 'ファイナンスパートナーズ株式会社',
+        industry: '金融',
+        phone: '092-555-6666',
+        email: 'nakamura@finance-partners.example.com',
+        address: '福岡県福岡市博多区博多駅前5-5-5',
+      },
+    }),
+    prisma.customer.upsert({
+      where: { customerId: 6 },
+      update: {},
+      create: {
+        customerName: '小林 由美',
+        companyName: 'ヘルスケアジャパン株式会社',
+        industry: '医療',
+        phone: '011-777-8888',
+        email: 'kobayashi@healthcare-jp.example.com',
+        address: '北海道札幌市中央区大通6-6-6',
+      },
+    }),
+  ]);
+  console.log(`Created ${customers.length} customers`);
+
+  // 日報データの作成（各ステータスのサンプル）
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const twoDaysAgo = new Date(today);
+  twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+
+  // 下書き日報（未使用変数のため_プレフィックス）
+  const _draftReport = await prisma.dailyReport.upsert({
+    where: {
+      salesId_reportDate: {
+        salesId: sales1.salesId,
+        reportDate: today,
+      },
+    },
+    update: {},
+    create: {
+      salesId: sales1.salesId,
+      reportDate: today,
+      problem: '新規顧客への提案内容を検討中です。',
+      plan: '明日は既存顧客へのフォローアップ訪問を予定しています。',
+      status: '下書き',
+    },
+  });
+  console.log(`Created draft report for ${sales1.salesName}`);
+
+  // 提出済み日報
+  const submittedReport = await prisma.dailyReport.upsert({
+    where: {
+      salesId_reportDate: {
+        salesId: sales1.salesId,
+        reportDate: yesterday,
+      },
+    },
+    update: {},
+    create: {
+      salesId: sales1.salesId,
+      reportDate: yesterday,
+      problem: '競合他社の提案があり、差別化ポイントの説明が必要でした。',
+      plan: '価格交渉の準備と上長への相談を予定しています。',
+      status: '提出済み',
+      submittedAt: yesterday,
+    },
+  });
+  console.log(`Created submitted report for ${sales1.salesName}`);
+
+  // 承認済み日報
+  const approvedReport = await prisma.dailyReport.upsert({
+    where: {
+      salesId_reportDate: {
+        salesId: sales2.salesId,
+        reportDate: yesterday,
+      },
+    },
+    update: {},
+    create: {
+      salesId: sales2.salesId,
+      reportDate: yesterday,
+      problem: 'なし',
+      plan: '新規開拓のためのテレアポを実施予定。',
+      status: '承認済み',
+      submittedAt: yesterday,
+      approvedAt: today,
+      approvedBy: manager.salesId,
+    },
+  });
+  console.log(`Created approved report for ${sales2.salesName}`);
+
+  // 差し戻し日報
+  const rejectedReport = await prisma.dailyReport.upsert({
+    where: {
+      salesId_reportDate: {
+        salesId: sales2.salesId,
+        reportDate: twoDaysAgo,
+      },
+    },
+    update: {},
+    create: {
+      salesId: sales2.salesId,
+      reportDate: twoDaysAgo,
+      problem: '内容を記載してください。',
+      plan: '詳細な計画を記載してください。',
+      status: '差し戻し',
+      submittedAt: twoDaysAgo,
+    },
+  });
+  console.log(`Created rejected report for ${sales2.salesName}`);
+
+  // 訪問記録データの作成
+  const visits = await Promise.all([
+    prisma.visit.create({
+      data: {
+        reportId: submittedReport.reportId,
+        customerId: customers[0].customerId,
+        visitContent:
+          '新製品の紹介とデモンストレーションを実施しました。先方は非常に関心を示されており、来週の見積り提出を依頼されました。',
+        visitTime: new Date('1970-01-01T10:00:00'),
+      },
+    }),
+    prisma.visit.create({
+      data: {
+        reportId: submittedReport.reportId,
+        customerId: customers[1].customerId,
+        visitContent:
+          '既存契約の更新について打ち合わせを行いました。契約条件の見直しを検討したいとのことで、次回具体的な提案を持参することになりました。',
+        visitTime: new Date('1970-01-01T14:30:00'),
+      },
+    }),
+    prisma.visit.create({
+      data: {
+        reportId: approvedReport.reportId,
+        customerId: customers[2].customerId,
+        visitContent:
+          'ITシステムの導入について初回ヒアリングを実施。現状の課題と要望を詳しく伺いました。RFPへの参加を依頼されました。',
+        visitTime: new Date('1970-01-01T11:00:00'),
+      },
+    }),
+    prisma.visit.create({
+      data: {
+        reportId: approvedReport.reportId,
+        customerId: customers[3].customerId,
+        visitContent:
+          '物流効率化の提案書を説明しました。費用対効果について追加の資料を求められました。',
+        visitTime: new Date('1970-01-01T15:00:00'),
+      },
+    }),
+  ]);
+  console.log(`Created ${visits.length} visits`);
+
+  // コメントデータの作成
+  const comments = await Promise.all([
+    prisma.comment.create({
+      data: {
+        reportId: submittedReport.reportId,
+        salesId: manager.salesId,
+        commentContent:
+          '競合対策について、明日のミーティングで詳しく相談しましょう。価格以外の差別化ポイントを整理しておいてください。',
+      },
+    }),
+    prisma.comment.create({
+      data: {
+        reportId: submittedReport.reportId,
+        salesId: sales1.salesId,
+        commentContent:
+          '承知しました。技術面での優位性と導入後のサポート体制について資料をまとめておきます。',
+      },
+    }),
+    prisma.comment.create({
+      data: {
+        reportId: approvedReport.reportId,
+        salesId: manager.salesId,
+        commentContent:
+          '良い活動ですね。RFPに向けてしっかり準備しましょう。何かあれば相談してください。',
+      },
+    }),
+    prisma.comment.create({
+      data: {
+        reportId: rejectedReport.reportId,
+        salesId: manager.salesId,
+        commentContent:
+          '報告内容が不十分です。訪問先と商談内容を具体的に記載してください。',
+      },
+    }),
+  ]);
+  console.log(`Created ${comments.length} comments`);
+
+  console.log('Seeding completed successfully!');
+  console.log('\n--- Test User Credentials ---');
+  console.log('Manager: manager@example.com / password123');
+  console.log('Sales 1: sales1@example.com / password123');
+  console.log('Sales 2: sales2@example.com / password123');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- prisma/seed.tsを作成し、開発・テスト用のシードデータを実装
- テスト用ユーザー（上長1名、一般営業2名）を作成
- テスト用顧客データ（6件）を作成
- 各ステータスの日報サンプル（下書き、提出済み、承認済み、差し戻し）を作成
- 訪問記録とコメントのサンプルデータを作成

## Changes
- `prisma/seed.ts`: シードデータスクリプト
- `package.json`: 
  - `bcryptjs`を追加（パスワードハッシュ化用）
  - `tsx`を追加（TypeScript実行用）
  - `seed`スクリプトと`prisma.seed`設定を追加

## Test Credentials
- Manager: manager@example.com / password123
- Sales 1: sales1@example.com / password123
- Sales 2: sales2@example.com / password123

## Test plan
- [ ] `npm install`で依存関係がインストールされることを確認
- [ ] `npx prisma db seed`でシードデータが投入されることを確認
- [ ] 作成されたユーザーでログインできることを確認

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)