### PR TITLE
feat: Issue #11 日報詳細画面の実装

### DIFF
--- a/src/app/(dashboard)/reports/[id]/page.tsx
+++ b/src/app/(dashboard)/reports/[id]/page.tsx
@@ -1,0 +1,365 @@
+import { redirect, notFound } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { authOptions, SessionUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { REPORT_STATUSES, ROLES, type ReportStatus } from '@/lib/constants';
+import { ReportDetailActions } from '@/components/features/reports/ReportDetailActions';
+import { CommentSection } from '@/components/features/reports/CommentSection';
+
+/**
+ * 日報詳細画面 (S-005)
+ *
+ * 機能:
+ * - 日報の詳細表示（基本情報、訪問記録、課題・相談、明日の予定、承認情報）
+ * - コメント一覧の表示
+ * - コメント投稿フォーム
+ * - 編集ボタン（本人 & 編集可能な状態）
+ * - 承認ボタン（上長のみ）
+ * - 差し戻しボタン（上長のみ）
+ *
+ * 権限:
+ * - 一般営業: 自分の日報のみ閲覧可能
+ * - 上長: 自分と配下メンバーの日報を閲覧可能
+ */
+export default async function ReportDetailPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const user = session.user as SessionUser;
+  const params = await props.params;
+  const reportId = parseInt(params.id, 10);
+
+  if (isNaN(reportId)) {
+    notFound();
+  }
+
+  // 日報を取得（訪問記録、コメント含む）
+  const report = await prisma.dailyReport.findUnique({
+    where: { reportId },
+    include: {
+      sales: {
+        select: {
+          salesId: true,
+          salesName: true,
+          department: true,
+        },
+      },
+      approver: {
+        select: {
+          salesId: true,
+          salesName: true,
+        },
+      },
+      visits: {
+        include: {
+          customer: {
+            select: {
+              customerId: true,
+              customerName: true,
+              companyName: true,
+            },
+          },
+        },
+        orderBy: {
+          visitTime: 'asc',
+        },
+      },
+      comments: {
+        include: {
+          sales: {
+            select: {
+              salesId: true,
+              salesName: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      },
+    },
+  });
+
+  if (!report) {
+    notFound();
+  }
+
+  // 権限チェック
+  let hasAccess = false;
+  if (report.salesId === user.salesId) {
+    hasAccess = true;
+  } else if (user.role === ROLES.MANAGER) {
+    const subordinates = await prisma.sales.findMany({
+      where: { managerId: user.salesId },
+      select: { salesId: true },
+    });
+    const allowedIds = [user.salesId, ...subordinates.map((s) => s.salesId)];
+    hasAccess = allowedIds.includes(report.salesId);
+  }
+
+  if (!hasAccess) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="mb-6">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/reports">&larr; 日報一覧に戻る</Link>
+          </Button>
+        </div>
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-destructive">
+            閲覧権限がありません
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            この日報を閲覧する権限がありません。
+          </p>
+          <Button variant="outline" className="mt-4" asChild>
+            <Link href="/reports">日報一覧に戻る</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // 編集可能かどうか
+  const canEdit =
+    report.salesId === user.salesId &&
+    (report.status === REPORT_STATUSES.DRAFT ||
+      report.status === REPORT_STATUSES.REJECTED);
+
+  // 承認・差し戻し可能かどうか（上長かつ提出済み）
+  const canApprove =
+    user.role === ROLES.MANAGER &&
+    report.status === REPORT_STATUSES.SUBMITTED &&
+    report.salesId !== user.salesId;
+
+  // ステータスに応じたバッジの色
+  const getStatusBadgeVariant = (
+    status: string
+  ): 'default' | 'secondary' | 'destructive' | 'outline' => {
+    switch (status) {
+      case REPORT_STATUSES.DRAFT:
+        return 'secondary';
+      case REPORT_STATUSES.SUBMITTED:
+        return 'default';
+      case REPORT_STATUSES.APPROVED:
+        return 'outline';
+      case REPORT_STATUSES.REJECTED:
+        return 'destructive';
+      default:
+        return 'secondary';
+    }
+  };
+
+  // 時刻のフォーマット
+  const formatTime = (date: Date): string => {
+    const hours = date.getUTCHours().toString().padStart(2, '0');
+    const minutes = date.getUTCMinutes().toString().padStart(2, '0');
+    return `${hours}:${minutes}`;
+  };
+
+  // 日時のフォーマット
+  const formatDateTime = (date: Date | null): string => {
+    if (!date) return '-';
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <div className="mb-4 flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/reports">&larr; 日報一覧に戻る</Link>
+          </Button>
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">日報詳細</h1>
+            <p className="text-muted-foreground mt-2">
+              {report.reportDate.toLocaleDateString('ja-JP')} の日報
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {canEdit && (
+              <Button asChild>
+                <Link href={`/reports/${reportId}/edit`}>編集</Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 基本情報カード */}
+      <Card>
+        <CardHeader>
+          <CardTitle>基本情報</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                営業担当者
+              </dt>
+              <dd className="mt-1 text-base">{report.sales.salesName}</dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                部署
+              </dt>
+              <dd className="mt-1 text-base">{report.sales.department}</dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                報告日
+              </dt>
+              <dd className="mt-1 text-base">
+                {report.reportDate.toLocaleDateString('ja-JP')}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                ステータス
+              </dt>
+              <dd className="mt-1">
+                <Badge variant={getStatusBadgeVariant(report.status)}>
+                  {report.status}
+                </Badge>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-sm font-medium text-muted-foreground">
+                提出日時
+              </dt>
+              <dd className="mt-1 text-base">
+                {formatDateTime(report.submittedAt)}
+              </dd>
+            </div>
+            {report.status === REPORT_STATUSES.APPROVED && (
+              <>
+                <div>
+                  <dt className="text-sm font-medium text-muted-foreground">
+                    承認日時
+                  </dt>
+                  <dd className="mt-1 text-base">
+                    {formatDateTime(report.approvedAt)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-sm font-medium text-muted-foreground">
+                    承認者
+                  </dt>
+                  <dd className="mt-1 text-base">
+                    {report.approver?.salesName || '-'}
+                  </dd>
+                </div>
+              </>
+            )}
+          </dl>
+        </CardContent>
+      </Card>
+
+      {/* 訪問記録カード */}
+      <Card>
+        <CardHeader>
+          <CardTitle>訪問記録 ({report.visits.length}件)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {report.visits.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              訪問記録がありません。
+            </p>
+          ) : (
+            <div className="divide-y">
+              {report.visits.map((visit) => (
+                <div key={visit.visitId} className="py-4 first:pt-0 last:pb-0">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 space-y-1">
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm font-medium text-muted-foreground">
+                          {formatTime(visit.visitTime)}
+                        </span>
+                        <span className="font-semibold">
+                          {visit.customer.companyName}
+                        </span>
+                        <span className="text-sm text-muted-foreground">
+                          ({visit.customer.customerName})
+                        </span>
+                      </div>
+                      <p className="text-sm whitespace-pre-wrap">
+                        {visit.visitContent}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 課題・相談 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>課題・相談</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {report.problem ? (
+            <p className="whitespace-pre-wrap text-sm">{report.problem}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">記載なし</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 明日の予定 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>明日の予定</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {report.plan ? (
+            <p className="whitespace-pre-wrap text-sm">{report.plan}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">記載なし</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 承認・差し戻しアクション */}
+      {canApprove && (
+        <ReportDetailActions
+          reportId={reportId}
+          currentStatus={report.status as ReportStatus}
+        />
+      )}
+
+      {/* コメントセクション */}
+      <CommentSection
+        reportId={reportId}
+        comments={report.comments.map((c) => ({
+          commentId: c.commentId,
+          salesId: c.salesId,
+          salesName: c.sales.salesName,
+          commentContent: c.commentContent,
+          createdAt: c.createdAt.toISOString(),
+        }))}
+        currentUserId={user.salesId}
+      />
+    </div>
+  );
+}

--- a/src/app/api/reports/[id]/approve/route.ts
+++ b/src/app/api/reports/[id]/approve/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions, SessionUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { REPORT_STATUSES, ROLES } from '@/lib/constants';
+
+/**
+ * 日報承認API
+ * POST /api/reports/[id]/approve
+ *
+ * 日報を承認します（上長のみ）。
+ * - ステータスを「承認済み」に変更
+ * - 承認日時と承認者を記録
+ */
+export async function POST(
+  _request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const user = session.user as SessionUser;
+    const params = await props.params;
+    const reportId = parseInt(params.id, 10);
+
+    if (isNaN(reportId)) {
+      return NextResponse.json({ error: '日報IDが不正です' }, { status: 400 });
+    }
+
+    // 上長権限チェック
+    if (user.role !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: '承認権限がありません' },
+        { status: 403 }
+      );
+    }
+
+    // 日報を取得
+    const report = await prisma.dailyReport.findUnique({
+      where: { reportId },
+      select: {
+        reportId: true,
+        salesId: true,
+        status: true,
+      },
+    });
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '日報が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 自分の日報は承認不可
+    if (report.salesId === user.salesId) {
+      return NextResponse.json(
+        { error: '自分の日報は承認できません' },
+        { status: 400 }
+      );
+    }
+
+    // 配下メンバーの日報かチェック
+    const subordinates = await prisma.sales.findMany({
+      where: { managerId: user.salesId },
+      select: { salesId: true },
+    });
+    const allowedIds = subordinates.map((s) => s.salesId);
+
+    if (!allowedIds.includes(report.salesId)) {
+      return NextResponse.json(
+        { error: '承認権限がありません' },
+        { status: 403 }
+      );
+    }
+
+    // ステータスチェック（提出済みのみ承認可能）
+    if (report.status !== REPORT_STATUSES.SUBMITTED) {
+      return NextResponse.json(
+        { error: '提出済みの日報のみ承認できます' },
+        { status: 400 }
+      );
+    }
+
+    // 日報を承認
+    const updatedReport = await prisma.dailyReport.update({
+      where: { reportId },
+      data: {
+        status: REPORT_STATUSES.APPROVED,
+        approvedAt: new Date(),
+        approvedBy: user.salesId,
+        updatedAt: new Date(),
+      },
+      include: {
+        sales: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+        approver: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({
+      message: '日報を承認しました',
+      report: updatedReport,
+    });
+  } catch (error) {
+    console.error('Failed to approve report:', error);
+    return NextResponse.json(
+      { error: '日報の承認に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/reports/[id]/comments/route.ts
+++ b/src/app/api/reports/[id]/comments/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions, SessionUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { ROLES } from '@/lib/constants';
+
+/**
+ * コメント投稿のバリデーションスキーマ
+ */
+const createCommentSchema = z.object({
+  content: z
+    .string()
+    .min(1, 'コメントを入力してください')
+    .max(1000, 'コメントは1000文字以内で入力してください'),
+});
+
+/**
+ * コメント一覧取得API
+ * GET /api/reports/[id]/comments
+ *
+ * 日報に紐づくコメント一覧を取得します。
+ * - 一般営業: 自分の日報のみ取得可能
+ * - 上長: 自分と配下メンバーの日報を取得可能
+ */
+export async function GET(
+  _request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const user = session.user as SessionUser;
+    const params = await props.params;
+    const reportId = parseInt(params.id, 10);
+
+    if (isNaN(reportId)) {
+      return NextResponse.json({ error: '日報IDが不正です' }, { status: 400 });
+    }
+
+    // 日報の存在確認と権限チェック
+    const report = await prisma.dailyReport.findUnique({
+      where: { reportId },
+      select: { salesId: true },
+    });
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '日報が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 権限チェック
+    let hasAccess = false;
+    if (report.salesId === user.salesId) {
+      hasAccess = true;
+    } else if (user.role === ROLES.MANAGER) {
+      const subordinates = await prisma.sales.findMany({
+        where: { managerId: user.salesId },
+        select: { salesId: true },
+      });
+      const allowedIds = [user.salesId, ...subordinates.map((s) => s.salesId)];
+      hasAccess = allowedIds.includes(report.salesId);
+    }
+
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: '閲覧権限がありません' },
+        { status: 403 }
+      );
+    }
+
+    // コメント取得
+    const comments = await prisma.comment.findMany({
+      where: { reportId },
+      include: {
+        sales: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return NextResponse.json({ comments });
+  } catch (error) {
+    console.error('Failed to fetch comments:', error);
+    return NextResponse.json(
+      { error: 'コメントの取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * コメント投稿API
+ * POST /api/reports/[id]/comments
+ *
+ * 日報にコメントを投稿します。
+ * - 一般営業: 自分の日報のみ投稿可能
+ * - 上長: 自分と配下メンバーの日報に投稿可能
+ */
+export async function POST(
+  request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const user = session.user as SessionUser;
+    const params = await props.params;
+    const reportId = parseInt(params.id, 10);
+
+    if (isNaN(reportId)) {
+      return NextResponse.json({ error: '日報IDが不正です' }, { status: 400 });
+    }
+
+    const body = await request.json();
+
+    // バリデーション
+    const validation = createCommentSchema.safeParse(body);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors[0]?.message;
+      return NextResponse.json(
+        { error: errorMessage || '入力内容に誤りがあります' },
+        { status: 400 }
+      );
+    }
+
+    const { content } = validation.data;
+
+    // 日報の存在確認と権限チェック
+    const report = await prisma.dailyReport.findUnique({
+      where: { reportId },
+      select: { salesId: true },
+    });
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '日報が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 権限チェック
+    let hasAccess = false;
+    if (report.salesId === user.salesId) {
+      hasAccess = true;
+    } else if (user.role === ROLES.MANAGER) {
+      const subordinates = await prisma.sales.findMany({
+        where: { managerId: user.salesId },
+        select: { salesId: true },
+      });
+      const allowedIds = [user.salesId, ...subordinates.map((s) => s.salesId)];
+      hasAccess = allowedIds.includes(report.salesId);
+    }
+
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: 'コメント投稿権限がありません' },
+        { status: 403 }
+      );
+    }
+
+    // コメント作成
+    const comment = await prisma.comment.create({
+      data: {
+        reportId,
+        salesId: user.salesId,
+        commentContent: content,
+      },
+      include: {
+        sales: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(
+      {
+        message: 'コメントを投稿しました',
+        comment,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('Failed to create comment:', error);
+    return NextResponse.json(
+      { error: 'コメントの投稿に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/reports/[id]/reject/route.ts
+++ b/src/app/api/reports/[id]/reject/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions, SessionUser } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { REPORT_STATUSES, ROLES } from '@/lib/constants';
+
+/**
+ * 差し戻しのバリデーションスキーマ
+ */
+const rejectSchema = z.object({
+  comment: z
+    .string()
+    .min(1, '差し戻し理由を入力してください')
+    .max(1000, '差し戻し理由は1000文字以内で入力してください'),
+});
+
+/**
+ * 日報差し戻しAPI
+ * POST /api/reports/[id]/reject
+ *
+ * 日報を差し戻します（上長のみ）。
+ * - ステータスを「差し戻し」に変更
+ * - 差し戻し理由をコメントとして記録
+ */
+export async function POST(
+  request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const user = session.user as SessionUser;
+    const params = await props.params;
+    const reportId = parseInt(params.id, 10);
+
+    if (isNaN(reportId)) {
+      return NextResponse.json({ error: '日報IDが不正です' }, { status: 400 });
+    }
+
+    // 上長権限チェック
+    if (user.role !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: '差し戻し権限がありません' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+
+    // バリデーション
+    const validation = rejectSchema.safeParse(body);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors[0]?.message;
+      return NextResponse.json(
+        { error: errorMessage || '入力内容に誤りがあります' },
+        { status: 400 }
+      );
+    }
+
+    const { comment } = validation.data;
+
+    // 日報を取得
+    const report = await prisma.dailyReport.findUnique({
+      where: { reportId },
+      select: {
+        reportId: true,
+        salesId: true,
+        status: true,
+      },
+    });
+
+    if (!report) {
+      return NextResponse.json(
+        { error: '日報が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 自分の日報は差し戻し不可
+    if (report.salesId === user.salesId) {
+      return NextResponse.json(
+        { error: '自分の日報は差し戻しできません' },
+        { status: 400 }
+      );
+    }
+
+    // 配下メンバーの日報かチェック
+    const subordinates = await prisma.sales.findMany({
+      where: { managerId: user.salesId },
+      select: { salesId: true },
+    });
+    const allowedIds = subordinates.map((s) => s.salesId);
+
+    if (!allowedIds.includes(report.salesId)) {
+      return NextResponse.json(
+        { error: '差し戻し権限がありません' },
+        { status: 403 }
+      );
+    }
+
+    // ステータスチェック（提出済みのみ差し戻し可能）
+    if (report.status !== REPORT_STATUSES.SUBMITTED) {
+      return NextResponse.json(
+        { error: '提出済みの日報のみ差し戻しできます' },
+        { status: 400 }
+      );
+    }
+
+    // トランザクションで日報更新とコメント作成を実行
+    const result = await prisma.$transaction(async (tx) => {
+      // 日報を差し戻し
+      const updatedReport = await tx.dailyReport.update({
+        where: { reportId },
+        data: {
+          status: REPORT_STATUSES.REJECTED,
+          updatedAt: new Date(),
+        },
+        include: {
+          sales: {
+            select: {
+              salesId: true,
+              salesName: true,
+            },
+          },
+        },
+      });
+
+      // 差し戻し理由をコメントとして記録
+      await tx.comment.create({
+        data: {
+          reportId,
+          salesId: user.salesId,
+          commentContent: `【差し戻し】${comment}`,
+        },
+      });
+
+      return updatedReport;
+    });
+
+    return NextResponse.json({
+      message: '日報を差し戻しました',
+      report: result,
+    });
+  } catch (error) {
+    console.error('Failed to reject report:', error);
+    return NextResponse.json(
+      { error: '日報の差し戻しに失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -14,7 +14,7 @@ import { REPORT_STATUSES } from '@/lib/constants';
  * - 上長: 自分と配下メンバーの日報を取得可能
  */
 export async function GET(
-  request: NextRequest,
+  _request: NextRequest,
   props: { params: Promise<{ id: string }> }
 ) {
   try {

--- a/src/components/features/reports/CommentSection.tsx
+++ b/src/components/features/reports/CommentSection.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+
+interface Comment {
+  commentId: number;
+  salesId: number;
+  salesName: string;
+  commentContent: string;
+  createdAt: string;
+}
+
+interface CommentSectionProps {
+  reportId: number;
+  comments: Comment[];
+  currentUserId: number;
+}
+
+/**
+ * コメントセクションコンポーネント
+ *
+ * 機能:
+ * - コメント一覧の表示（新しい順）
+ * - コメント投稿フォーム
+ */
+export function CommentSection({
+  reportId,
+  comments,
+  currentUserId,
+}: CommentSectionProps) {
+  const router = useRouter();
+  const [newComment, setNewComment] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!newComment.trim()) {
+      setError('コメントを入力してください');
+      return;
+    }
+
+    if (newComment.length > 1000) {
+      setError('コメントは1000文字以内で入力してください');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/reports/${reportId}/comments`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ content: newComment }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'コメントの投稿に失敗しました');
+      }
+
+      setNewComment('');
+      router.refresh();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'コメントの投稿に失敗しました'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const formatDateTime = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>コメント ({comments.length}件)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* コメント投稿フォーム */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Textarea
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              placeholder="コメントを入力..."
+              rows={3}
+              maxLength={1000}
+            />
+            <p className="mt-1 text-xs text-muted-foreground text-right">
+              {newComment.length}/1000
+            </p>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex justify-end">
+            <Button type="submit" disabled={isSubmitting || !newComment.trim()}>
+              {isSubmitting ? '投稿中...' : 'コメント投稿'}
+            </Button>
+          </div>
+        </form>
+
+        {/* コメント一覧 */}
+        {comments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            まだコメントはありません。
+          </p>
+        ) : (
+          <div className="divide-y">
+            {comments.map((comment) => (
+              <div
+                key={comment.commentId}
+                className="py-4 first:pt-0 last:pb-0"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">
+                        {comment.salesName}
+                        {comment.salesId === currentUserId && (
+                          <span className="ml-1 text-xs text-muted-foreground">
+                            (自分)
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {formatDateTime(comment.createdAt)}
+                      </span>
+                    </div>
+                    <p className="text-sm whitespace-pre-wrap">
+                      {comment.commentContent}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/features/reports/ReportDetailActions.tsx
+++ b/src/components/features/reports/ReportDetailActions.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { type ReportStatus } from '@/lib/constants';
+
+interface ReportDetailActionsProps {
+  reportId: number;
+  currentStatus: ReportStatus;
+}
+
+/**
+ * 日報詳細画面のアクションコンポーネント（承認・差し戻し）
+ *
+ * 上長のみが使用可能
+ * - 承認: ステータスを「承認済み」に変更
+ * - 差し戻し: ステータスを「差し戻し」に変更（コメント必須）
+ */
+export function ReportDetailActions({
+  reportId,
+  currentStatus,
+}: ReportDetailActionsProps) {
+  const router = useRouter();
+  const [isApproving, setIsApproving] = useState(false);
+  const [isRejecting, setIsRejecting] = useState(false);
+  const [showRejectDialog, setShowRejectDialog] = useState(false);
+  const [rejectComment, setRejectComment] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleApprove = async () => {
+    setIsApproving(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/reports/${reportId}/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || '承認に失敗しました');
+      }
+
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '承認に失敗しました');
+    } finally {
+      setIsApproving(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!rejectComment.trim()) {
+      setError('差し戻し理由を入力してください');
+      return;
+    }
+
+    setIsRejecting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/reports/${reportId}/reject`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ comment: rejectComment }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || '差し戻しに失敗しました');
+      }
+
+      setShowRejectDialog(false);
+      setRejectComment('');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '差し戻しに失敗しました');
+    } finally {
+      setIsRejecting(false);
+    }
+  };
+
+  if (currentStatus !== '提出済み') {
+    return null;
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>承認アクション</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="mb-4 rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+          <div className="flex gap-4">
+            <Button
+              onClick={handleApprove}
+              disabled={isApproving || isRejecting}
+            >
+              {isApproving ? '承認中...' : '承認'}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => setShowRejectDialog(true)}
+              disabled={isApproving || isRejecting}
+            >
+              差し戻し
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 差し戻しダイアログ */}
+      <Dialog open={showRejectDialog} onOpenChange={setShowRejectDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>日報を差し戻す</DialogTitle>
+            <DialogDescription>
+              差し戻し理由を入力してください。入力した内容はコメントとして記録されます。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="rejectComment">差し戻し理由</Label>
+              <Textarea
+                id="rejectComment"
+                value={rejectComment}
+                onChange={(e) => setRejectComment(e.target.value)}
+                placeholder="差し戻し理由を入力してください"
+                className="mt-2"
+                rows={4}
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowRejectDialog(false);
+                setRejectComment('');
+                setError(null);
+              }}
+              disabled={isRejecting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleReject}
+              disabled={isRejecting || !rejectComment.trim()}
+            >
+              {isRejecting ? '差し戻し中...' : '差し戻す'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- 日報詳細画面 (S-005) を実装
- コメント機能（一覧表示、投稿）を実装
- 承認・差し戻し機能（上長のみ）を実装

## 変更内容
### 追加ファイル
- `src/app/(dashboard)/reports/[id]/page.tsx` - 日報詳細画面
- `src/components/features/reports/ReportDetailActions.tsx` - 承認・差し戻しアクション
- `src/components/features/reports/CommentSection.tsx` - コメントセクション
- `src/app/api/reports/[id]/comments/route.ts` - コメントAPI
- `src/app/api/reports/[id]/approve/route.ts` - 承認API
- `src/app/api/reports/[id]/reject/route.ts` - 差し戻しAPI

### 機能詳細
- 日報の詳細情報表示
  - 基本情報（日付、担当者、ステータス）
  - 訪問記録一覧
  - 課題・相談
  - 明日の予定
  - 承認情報
- コメント一覧の表示
- コメント投稿フォーム
- 編集ボタン（本人 & 編集可能な状態）
- 承認ボタン（上長のみ）
- 差し戻しボタン（上長のみ）

## Test plan
- [ ] 日報詳細画面が正しく表示される
- [ ] 訪問記録一覧が表示される
- [ ] コメントを投稿できる
- [ ] 上長でログイン時に承認・差し戻しボタンが表示される
- [ ] 承認処理が正しく動作する
- [ ] 差し戻し処理が正しく動作する
- [ ] 権限のない日報にアクセスした場合にエラーが表示される

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)