### PR TITLE
feat: Issue #13 顧客マスタ登録・編集画面の実装

### DIFF
--- a/src/app/(dashboard)/customers/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/customers/[id]/edit/page.tsx
@@ -1,0 +1,128 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { Button } from '@/components/ui/button';
+import { CustomerForm } from '@/components/features/customers/CustomerForm';
+import { type Industry } from '@/lib/constants';
+
+/**
+ * 顧客マスタ編集画面 (S-007)
+ *
+ * 機能:
+ * - 顧客情報の編集
+ * - 会社名、顧客担当者名の編集（必須）
+ * - 業種、電話番号、メールアドレス、住所の編集（任意）
+ *
+ * 権限:
+ * - すべての認証済みユーザーがアクセス可能
+ */
+export default async function EditCustomerPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const params = await props.params;
+  const customerId = parseInt(params.id, 10);
+
+  if (isNaN(customerId)) {
+    redirect('/customers');
+  }
+
+  try {
+    // 顧客情報を取得
+    const customer = await prisma.customer.findUnique({
+      where: { customerId },
+      select: {
+        customerId: true,
+        customerName: true,
+        companyName: true,
+        industry: true,
+        phone: true,
+        email: true,
+        address: true,
+      },
+    });
+
+    if (!customer) {
+      return (
+        <div className="container mx-auto p-6">
+          <div className="mb-6">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/customers">← 顧客一覧に戻る</Link>
+            </Button>
+          </div>
+          <div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-center">
+            <h2 className="text-lg font-semibold text-destructive">
+              顧客が見つかりません
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              指定された顧客は存在しません。
+            </p>
+            <Button variant="outline" className="mt-4" asChild>
+              <Link href="/customers">顧客一覧に戻る</Link>
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="container mx-auto space-y-6 p-6">
+        {/* ヘッダー */}
+        <div className="mb-6">
+          <div className="mb-4 flex items-center gap-2">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/customers">← 顧客一覧に戻る</Link>
+            </Button>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">顧客編集</h1>
+          <p className="text-muted-foreground mt-2">
+            顧客情報を編集します（{customer.companyName}）
+          </p>
+        </div>
+
+        {/* 顧客編集フォーム */}
+        <CustomerForm
+          mode="edit"
+          customerId={customerId}
+          initialData={{
+            companyName: customer.companyName,
+            customerName: customer.customerName,
+            industry: customer.industry as Industry | null,
+            phone: customer.phone,
+            email: customer.email,
+            address: customer.address,
+          }}
+        />
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to load edit customer page:', error);
+    return (
+      <div className="container mx-auto p-6">
+        <div className="mb-6">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/customers">← 顧客一覧に戻る</Link>
+          </Button>
+        </div>
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-destructive">
+            データの取得に失敗しました
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            しばらくしてから再度お試しください。問題が解決しない場合は管理者にお問い合わせください。
+          </p>
+          <Button variant="outline" className="mt-4" asChild>
+            <Link href={`/customers/${customerId}/edit`}>再読み込み</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/app/(dashboard)/customers/new/page.tsx
+++ b/src/app/(dashboard)/customers/new/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { Button } from '@/components/ui/button';
+import { CustomerForm } from '@/components/features/customers/CustomerForm';
+
+/**
+ * 顧客マスタ登録画面 (S-007)
+ *
+ * 機能:
+ * - 顧客情報の新規登録
+ * - 会社名、顧客担当者名の入力（必須）
+ * - 業種、電話番号、メールアドレス、住所の入力（任意）
+ *
+ * 権限:
+ * - すべての認証済みユーザーがアクセス可能
+ */
+export default async function NewCustomerPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <div className="mb-4 flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/customers">← 顧客一覧に戻る</Link>
+          </Button>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight">顧客登録</h1>
+        <p className="text-muted-foreground mt-2">新しい顧客を登録します</p>
+      </div>
+
+      {/* 顧客フォーム */}
+      <CustomerForm mode="create" />
+    </div>
+  );
+}

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,0 +1,210 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { updateCustomerSchema } from '@/lib/validations/customer';
+
+/**
+ * 顧客詳細取得API
+ * GET /api/customers/[id]
+ *
+ * 指定されたIDの顧客情報を取得します。
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const customerId = parseInt(params.id, 10);
+
+    if (isNaN(customerId)) {
+      return NextResponse.json({ error: '無効な顧客IDです' }, { status: 400 });
+    }
+
+    // 顧客情報を取得
+    const customer = await prisma.customer.findUnique({
+      where: { customerId },
+      select: {
+        customerId: true,
+        customerName: true,
+        companyName: true,
+        industry: true,
+        phone: true,
+        email: true,
+        address: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!customer) {
+      return NextResponse.json(
+        { error: '顧客が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ data: customer });
+  } catch (error) {
+    console.error('Failed to fetch customer:', error);
+    return NextResponse.json(
+      { error: '顧客情報の取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * 顧客更新API
+ * PUT /api/customers/[id]
+ *
+ * 指定されたIDの顧客情報を更新します。
+ */
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const customerId = parseInt(params.id, 10);
+
+    if (isNaN(customerId)) {
+      return NextResponse.json({ error: '無効な顧客IDです' }, { status: 400 });
+    }
+
+    // 顧客の存在確認
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { customerId },
+    });
+
+    if (!existingCustomer) {
+      return NextResponse.json(
+        { error: '顧客が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // リクエストボディを取得
+    const body = await request.json();
+
+    // バリデーション
+    const validation = updateCustomerSchema.safeParse(body);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors[0]?.message;
+      return NextResponse.json(
+        { error: errorMessage || '入力内容に誤りがあります' },
+        { status: 400 }
+      );
+    }
+
+    const data = validation.data;
+
+    // 顧客情報を更新
+    const customer = await prisma.customer.update({
+      where: { customerId },
+      data: {
+        companyName: data.companyName,
+        customerName: data.customerName,
+        industry: data.industry || null,
+        phone: data.phone || null,
+        email: data.email || null,
+        address: data.address || null,
+      },
+      select: {
+        customerId: true,
+        customerName: true,
+        companyName: true,
+        industry: true,
+        phone: true,
+        email: true,
+        address: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return NextResponse.json({ data: customer });
+  } catch (error) {
+    console.error('Failed to update customer:', error);
+    return NextResponse.json(
+      { error: '顧客情報の更新に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * 顧客削除API
+ * DELETE /api/customers/[id]
+ *
+ * 指定されたIDの顧客を削除します。
+ * 訪問記録に紐づいている場合は削除できません。
+ */
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const params = await context.params;
+    const customerId = parseInt(params.id, 10);
+
+    if (isNaN(customerId)) {
+      return NextResponse.json({ error: '無効な顧客IDです' }, { status: 400 });
+    }
+
+    // 顧客の存在確認
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { customerId },
+      include: {
+        visits: true,
+      },
+    });
+
+    if (!existingCustomer) {
+      return NextResponse.json(
+        { error: '顧客が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 訪問記録が紐づいている場合は削除不可
+    if (existingCustomer.visits.length > 0) {
+      return NextResponse.json(
+        { error: 'この顧客は訪問記録に使用されているため削除できません' },
+        { status: 400 }
+      );
+    }
+
+    // 顧客を削除
+    await prisma.customer.delete({
+      where: { customerId },
+    });
+
+    return NextResponse.json({ message: '顧客を削除しました' });
+  } catch (error) {
+    console.error('Failed to delete customer:', error);
+    return NextResponse.json(
+      { error: '顧客の削除に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/features/customers/CustomerForm.tsx
+++ b/src/components/features/customers/CustomerForm.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  customerFormSchema,
+  type CustomerFormInput,
+} from '@/lib/validations/customer';
+import { INDUSTRIES } from '@/lib/constants';
+
+interface CustomerFormProps {
+  mode: 'create' | 'edit';
+  customerId?: number;
+  initialData?: CustomerFormInput;
+}
+
+/**
+ * 顧客フォームコンポーネント
+ *
+ * 顧客マスタの登録・編集を行うフォーム
+ * - 会社名の入力（必須）
+ * - 顧客担当者名の入力（必須）
+ * - 業種の選択（任意）
+ * - 電話番号の入力（任意）
+ * - メールアドレスの入力（任意）
+ * - 住所の入力（任意）
+ */
+export function CustomerForm({
+  mode,
+  customerId,
+  initialData,
+}: CustomerFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<CustomerFormInput>({
+    resolver: zodResolver(customerFormSchema),
+    defaultValues: initialData || {
+      companyName: '',
+      customerName: '',
+      industry: null,
+      phone: '',
+      email: '',
+      address: '',
+    },
+  });
+
+  /**
+   * フォーム送信処理
+   */
+  const onSubmit = async (data: CustomerFormInput) => {
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const url =
+        mode === 'create' ? '/api/customers' : `/api/customers/${customerId}`;
+      const method = mode === 'create' ? 'POST' : 'PUT';
+
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          companyName: data.companyName,
+          customerName: data.customerName,
+          industry: data.industry || null,
+          phone: data.phone || null,
+          email: data.email || null,
+          address: data.address || null,
+        }),
+      });
+
+      const responseData = await response.json();
+
+      if (!response.ok) {
+        throw new Error(
+          responseData.error ||
+            `顧客の${mode === 'create' ? '登録' : '更新'}に失敗しました`
+        );
+      }
+
+      router.push('/customers');
+      router.refresh();
+    } catch (err) {
+      console.error(`Failed to ${mode} customer:`, err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : `顧客の${mode === 'create' ? '登録' : '更新'}に失敗しました`
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * キャンセル処理
+   */
+  const handleCancel = () => {
+    router.push('/customers');
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* エラーメッセージ */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          {/* 基本情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle>基本情報</CardTitle>
+              <CardDescription>
+                顧客の基本情報を入力してください
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* 会社名 */}
+              <FormField
+                control={form.control}
+                name="companyName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      会社名 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="株式会社サンプル"
+                        maxLength={255}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 顧客担当者名 */}
+              <FormField
+                control={form.control}
+                name="customerName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      顧客担当者名 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="山田 太郎"
+                        maxLength={100}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 業種 */}
+              <FormField
+                control={form.control}
+                name="industry"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>業種</FormLabel>
+                    <Select
+                      onValueChange={(value) => field.onChange(value || null)}
+                      value={field.value || undefined}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="業種を選択してください" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value={INDUSTRIES.IT}>
+                          {INDUSTRIES.IT}
+                        </SelectItem>
+                        <SelectItem value={INDUSTRIES.MANUFACTURING}>
+                          {INDUSTRIES.MANUFACTURING}
+                        </SelectItem>
+                        <SelectItem value={INDUSTRIES.FINANCE}>
+                          {INDUSTRIES.FINANCE}
+                        </SelectItem>
+                        <SelectItem value={INDUSTRIES.RETAIL}>
+                          {INDUSTRIES.RETAIL}
+                        </SelectItem>
+                        <SelectItem value={INDUSTRIES.SERVICE}>
+                          {INDUSTRIES.SERVICE}
+                        </SelectItem>
+                        <SelectItem value={INDUSTRIES.OTHER}>
+                          {INDUSTRIES.OTHER}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          {/* 連絡先情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle>連絡先情報</CardTitle>
+              <CardDescription>
+                顧客の連絡先情報を入力してください（任意）
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* 電話番号 */}
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>電話番号</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="tel"
+                        placeholder="03-1234-5678"
+                        maxLength={20}
+                        {...field}
+                        value={field.value || ''}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* メールアドレス */}
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>メールアドレス</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="sample@example.com"
+                        maxLength={255}
+                        {...field}
+                        value={field.value || ''}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 住所 */}
+              <FormField
+                control={form.control}
+                name="address"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>住所</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="東京都渋谷区..."
+                        className="min-h-[100px] resize-none"
+                        maxLength={500}
+                        {...field}
+                        value={field.value || ''}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <div className="flex justify-between text-xs text-muted-foreground">
+                      <FormMessage />
+                      <span>{(field.value || '').length} / 500</span>
+                    </div>
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          {/* 送信ボタン */}
+          <div className="flex justify-end gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting
+                ? mode === 'create'
+                  ? '登録中...'
+                  : '更新中...'
+                : mode === 'create'
+                  ? '登録'
+                  : '更新'}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,3 +24,17 @@ export const REPORT_STATUSES = {
 
 export type ReportStatus =
   (typeof REPORT_STATUSES)[keyof typeof REPORT_STATUSES];
+
+/**
+ * 業種
+ */
+export const INDUSTRIES = {
+  IT: 'IT',
+  MANUFACTURING: '製造',
+  FINANCE: '金融',
+  RETAIL: '小売',
+  SERVICE: 'サービス',
+  OTHER: 'その他',
+} as const;
+
+export type Industry = (typeof INDUSTRIES)[keyof typeof INDUSTRIES];

--- a/src/lib/validations/customer.ts
+++ b/src/lib/validations/customer.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+import { INDUSTRIES } from '@/lib/constants';
+
+/**
+ * 電話番号のバリデーション（数字とハイフンのみ）
+ */
+const phoneRegex = /^[0-9-]*$/;
+
+/**
+ * 顧客フォームのバリデーションスキーマ
+ */
+export const customerFormSchema = z.object({
+  companyName: z
+    .string()
+    .min(1, '会社名を入力してください。')
+    .max(255, '会社名は255文字以内で入力してください。'),
+  customerName: z
+    .string()
+    .min(1, '顧客担当者名を入力してください。')
+    .max(100, '顧客担当者名は100文字以内で入力してください。'),
+  industry: z
+    .enum(
+      [
+        INDUSTRIES.IT,
+        INDUSTRIES.MANUFACTURING,
+        INDUSTRIES.FINANCE,
+        INDUSTRIES.RETAIL,
+        INDUSTRIES.SERVICE,
+        INDUSTRIES.OTHER,
+      ],
+      {
+        errorMap: () => ({ message: '業種を選択してください。' }),
+      }
+    )
+    .optional()
+    .nullable(),
+  phone: z
+    .string()
+    .max(20, '電話番号は20文字以内で入力してください。')
+    .regex(phoneRegex, '電話番号の形式が正しくありません。')
+    .optional()
+    .nullable()
+    .or(z.literal('')),
+  email: z
+    .string()
+    .email('メールアドレスの形式が正しくありません。')
+    .max(255, 'メールアドレスは255文字以内で入力してください。')
+    .optional()
+    .nullable()
+    .or(z.literal('')),
+  address: z
+    .string()
+    .max(500, '住所は500文字以内で入力してください。')
+    .optional()
+    .nullable()
+    .or(z.literal('')),
+});
+
+/**
+ * 顧客作成APIリクエストのバリデーションスキーマ
+ */
+export const createCustomerSchema = z.object({
+  companyName: z
+    .string()
+    .min(1, '会社名を入力してください。')
+    .max(255, '会社名は255文字以内で入力してください。'),
+  customerName: z
+    .string()
+    .min(1, '顧客担当者名を入力してください。')
+    .max(100, '顧客担当者名は100文字以内で入力してください。'),
+  industry: z
+    .enum([
+      INDUSTRIES.IT,
+      INDUSTRIES.MANUFACTURING,
+      INDUSTRIES.FINANCE,
+      INDUSTRIES.RETAIL,
+      INDUSTRIES.SERVICE,
+      INDUSTRIES.OTHER,
+    ])
+    .optional()
+    .nullable(),
+  phone: z
+    .string()
+    .max(20, '電話番号は20文字以内で入力してください。')
+    .regex(phoneRegex, '電話番号の形式が正しくありません。')
+    .optional()
+    .nullable(),
+  email: z
+    .string()
+    .email('メールアドレスの形式が正しくありません。')
+    .max(255, 'メールアドレスは255文字以内で入力してください。')
+    .optional()
+    .nullable(),
+  address: z
+    .string()
+    .max(500, '住所は500文字以内で入力してください。')
+    .optional()
+    .nullable(),
+});
+
+/**
+ * 顧客更新APIリクエストのバリデーションスキーマ
+ */
+export const updateCustomerSchema = createCustomerSchema;
+
+/**
+ * 型定義
+ */
+export type CustomerFormInput = z.infer<typeof customerFormSchema>;
+export type CreateCustomerInput = z.infer<typeof createCustomerSchema>;
+export type UpdateCustomerInput = z.infer<typeof updateCustomerSchema>;


### PR DESCRIPTION
## Summary
- 顧客マスタ登録画面のUIを実装（`src/app/(dashboard)/customers/new/page.tsx`）
- 顧客マスタ編集画面のUIを実装（`src/app/(dashboard)/customers/[id]/edit/page.tsx`）
- 顧客フォームコンポーネントの実装（会社名、顧客担当者名、業種、電話番号、メールアドレス、住所）
- フォームバリデーション（Zod）
- 登録・更新処理とAPI連携

## Test plan
- [ ] 顧客を新規登録できる
- [ ] 既存顧客を編集できる
- [ ] 会社名・顧客担当者名が未入力の場合、バリデーションエラーが表示される
- [ ] 電話番号の形式が不正な場合、エラーが表示される
- [ ] メールアドレスの形式が不正な場合、エラーが表示される
- [ ] 登録・更新後に一覧画面に遷移する

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)