### PR TITLE
feat: Issue #14 営業マスタ一覧・登録画面の実装

### DIFF
--- a/src/app/(dashboard)/sales/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/sales/[id]/edit/page.tsx
@@ -1,0 +1,133 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { Button } from '@/components/ui/button';
+import { SalesForm } from '@/components/features/sales/SalesForm';
+import { ROLES, type Role } from '@/lib/constants';
+
+/**
+ * 営業マスタ編集画面 (S-009)
+ *
+ * 機能:
+ * - 営業担当者情報の編集
+ * - 営業担当者名、メールアドレス、所属部署の編集（必須）
+ * - 役割の変更（必須）
+ * - 上長の変更（任意）
+ *
+ * 権限:
+ * - 上長のみアクセス可能
+ */
+export default async function EditSalesPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // 権限チェック（上長のみアクセス可）
+  const userRole = (session.user as any).role;
+  if (userRole !== ROLES.MANAGER) {
+    redirect('/dashboard');
+  }
+
+  const params = await props.params;
+  const salesId = parseInt(params.id, 10);
+
+  if (isNaN(salesId)) {
+    redirect('/sales');
+  }
+
+  try {
+    // 営業担当者情報を取得
+    const sales = await prisma.sales.findUnique({
+      where: { salesId },
+      select: {
+        salesId: true,
+        salesName: true,
+        email: true,
+        department: true,
+        role: true,
+        managerId: true,
+      },
+    });
+
+    if (!sales) {
+      return (
+        <div className="container mx-auto p-6">
+          <div className="mb-6">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/sales">&larr; 営業一覧に戻る</Link>
+            </Button>
+          </div>
+          <div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-center">
+            <h2 className="text-lg font-semibold text-destructive">
+              営業担当者が見つかりません
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              指定された営業担当者は存在しません。
+            </p>
+            <Button variant="outline" className="mt-4" asChild>
+              <Link href="/sales">営業一覧に戻る</Link>
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="container mx-auto space-y-6 p-6">
+        {/* ヘッダー */}
+        <div className="mb-6">
+          <div className="mb-4 flex items-center gap-2">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/sales">&larr; 営業一覧に戻る</Link>
+            </Button>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">営業担当者編集</h1>
+          <p className="text-muted-foreground mt-2">
+            営業担当者情報を編集します（{sales.salesName}）
+          </p>
+        </div>
+
+        {/* 営業担当者編集フォーム */}
+        <SalesForm
+          mode="edit"
+          salesId={salesId}
+          initialData={{
+            salesName: sales.salesName,
+            email: sales.email,
+            department: sales.department,
+            role: sales.role as Role,
+            managerId: sales.managerId,
+          }}
+        />
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to load edit sales page:', error);
+    return (
+      <div className="container mx-auto p-6">
+        <div className="mb-6">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/sales">&larr; 営業一覧に戻る</Link>
+          </Button>
+        </div>
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-destructive">
+            データの取得に失敗しました
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            しばらくしてから再度お試しください。問題が解決しない場合は管理者にお問い合わせください。
+          </p>
+          <Button variant="outline" className="mt-4" asChild>
+            <Link href={`/sales/${salesId}/edit`}>再読み込み</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/app/(dashboard)/sales/new/page.tsx
+++ b/src/app/(dashboard)/sales/new/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { Button } from '@/components/ui/button';
+import { SalesForm } from '@/components/features/sales/SalesForm';
+import { ROLES } from '@/lib/constants';
+
+/**
+ * 営業マスタ登録画面 (S-009)
+ *
+ * 機能:
+ * - 営業担当者情報の新規登録
+ * - 営業担当者名、メールアドレス、パスワード、所属部署の入力（必須）
+ * - 役割の選択（必須）
+ * - 上長の選択（任意）
+ *
+ * 権限:
+ * - 上長のみアクセス可能
+ */
+export default async function NewSalesPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // 権限チェック（上長のみアクセス可）
+  const userRole = (session.user as any).role;
+  if (userRole !== ROLES.MANAGER) {
+    redirect('/dashboard');
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <div className="mb-4 flex items-center gap-2">
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/sales">&larr; 営業一覧に戻る</Link>
+          </Button>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight">営業担当者登録</h1>
+        <p className="text-muted-foreground mt-2">
+          新しい営業担当者を登録します
+        </p>
+      </div>
+
+      {/* 営業担当者フォーム */}
+      <SalesForm mode="create" />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/page.tsx
+++ b/src/app/(dashboard)/sales/page.tsx
@@ -1,0 +1,411 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { ROLES } from '@/lib/constants';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { SalesFilters } from './sales-filters';
+
+/**
+ * 営業マスタ一覧画面 (S-008)
+ *
+ * 機能:
+ * - 営業担当者情報の一覧表示
+ * - フィルタ機能（担当者名、部署、役割）
+ * - ソート機能
+ * - ページネーション
+ *
+ * 権限:
+ * - 上長のみアクセス可能
+ */
+
+interface SearchParams {
+  salesName?: string;
+  department?: string;
+  role?: string;
+  page?: string;
+  sortBy?: string;
+  sortOrder?: string;
+}
+
+const PAGE_SIZE = 10;
+
+// 役割の選択肢
+const ROLE_OPTIONS = [
+  { value: '', label: 'すべて' },
+  { value: ROLES.SALES, label: ROLES.SALES },
+  { value: ROLES.MANAGER, label: ROLES.MANAGER },
+] as const;
+
+export default async function SalesPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // 権限チェック（上長のみアクセス可）
+  const userRole = (session.user as any).role;
+  if (userRole !== ROLES.MANAGER) {
+    redirect('/dashboard');
+  }
+
+  const params = await searchParams;
+
+  // パラメータの取得
+  const salesName = params.salesName || '';
+  const department = params.department || '';
+  const role = params.role || '';
+  const page = parseInt(params.page || '1', 10);
+  const sortBy = params.sortBy || 'salesName';
+  const sortOrder = (params.sortOrder || 'asc') as 'asc' | 'desc';
+
+  try {
+    // 部署の選択肢を取得
+    const departments = await prisma.sales.findMany({
+      select: { department: true },
+      distinct: ['department'],
+      orderBy: { department: 'asc' },
+    });
+
+    const departmentOptions = [
+      { value: '', label: 'すべて' },
+      ...departments.map((d) => ({ value: d.department, label: d.department })),
+    ];
+
+    // 検索条件の構築
+    const where = {
+      ...(salesName && {
+        salesName: { contains: salesName },
+      }),
+      ...(department && { department }),
+      ...(role && { role }),
+    };
+
+    // ソート条件の構築
+    const orderBy: Record<string, 'asc' | 'desc'> = {
+      [sortBy]: sortOrder,
+    };
+
+    // 総件数取得とデータ取得を並列実行
+    const [totalCount, salesList] = await Promise.all([
+      prisma.sales.count({ where }),
+      prisma.sales.findMany({
+        where,
+        select: {
+          salesId: true,
+          salesName: true,
+          email: true,
+          department: true,
+          role: true,
+          managerId: true,
+          manager: {
+            select: {
+              salesId: true,
+              salesName: true,
+            },
+          },
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy,
+        skip: (page - 1) * PAGE_SIZE,
+        take: PAGE_SIZE,
+      }),
+    ]);
+
+    const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+    return (
+      <div className="container mx-auto space-y-6 p-6">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">
+              営業マスタ一覧
+            </h1>
+            <p className="text-muted-foreground mt-2">
+              営業担当者情報の管理ができます
+            </p>
+          </div>
+          <Button asChild>
+            <Link href="/sales/new">新規営業担当者登録</Link>
+          </Button>
+        </div>
+
+        {/* 検索フィルタ */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">検索条件</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SalesFilters
+              salesName={salesName}
+              department={department}
+              role={role}
+              departmentOptions={departmentOptions}
+              roleOptions={ROLE_OPTIONS}
+            />
+          </CardContent>
+        </Card>
+
+        {/* 検索結果 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">検索結果</CardTitle>
+            <CardDescription>全 {totalCount} 件</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {salesList.length > 0 ? (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>
+                        <SortableHeader
+                          label="担当者名"
+                          field="salesName"
+                          currentSort={sortBy}
+                          currentOrder={sortOrder}
+                          params={params}
+                        />
+                      </TableHead>
+                      <TableHead>
+                        <SortableHeader
+                          label="部署"
+                          field="department"
+                          currentSort={sortBy}
+                          currentOrder={sortOrder}
+                          params={params}
+                        />
+                      </TableHead>
+                      <TableHead>
+                        <SortableHeader
+                          label="役割"
+                          field="role"
+                          currentSort={sortBy}
+                          currentOrder={sortOrder}
+                          params={params}
+                        />
+                      </TableHead>
+                      <TableHead>上長</TableHead>
+                      <TableHead>操作</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {salesList.map((sales) => (
+                      <TableRow key={sales.salesId}>
+                        <TableCell className="font-medium">
+                          {sales.salesName}
+                        </TableCell>
+                        <TableCell>{sales.department}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              sales.role === ROLES.MANAGER
+                                ? 'default'
+                                : 'secondary'
+                            }
+                          >
+                            {sales.role}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{sales.manager?.salesName || '-'}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button variant="outline" size="sm" asChild>
+                              <Link href={`/sales/${sales.salesId}/edit`}>
+                                編集
+                              </Link>
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+
+                {/* ページネーション */}
+                {totalPages > 1 && (
+                  <Pagination
+                    currentPage={page}
+                    totalPages={totalPages}
+                    params={params}
+                  />
+                )}
+              </>
+            ) : (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                該当する営業担当者がいません
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  } catch (error) {
+    console.error('Failed to fetch sales list:', error);
+    return (
+      <div className="container mx-auto p-6">
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-center">
+          <h2 className="text-lg font-semibold text-destructive">
+            データの取得に失敗しました
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            しばらくしてから再度お試しください。問題が解決しない場合は管理者にお問い合わせください。
+          </p>
+          <Button variant="outline" className="mt-4" asChild>
+            <Link href="/sales">再読み込み</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+/**
+ * ソート可能なヘッダー
+ */
+function SortableHeader({
+  label,
+  field,
+  currentSort,
+  currentOrder,
+  params,
+}: {
+  label: string;
+  field: string;
+  currentSort: string;
+  currentOrder: string;
+  params: SearchParams;
+}) {
+  const isActive = currentSort === field;
+  const nextOrder = isActive && currentOrder === 'asc' ? 'desc' : 'asc';
+
+  const queryParams = new URLSearchParams();
+  if (params.salesName) queryParams.set('salesName', params.salesName);
+  if (params.department) queryParams.set('department', params.department);
+  if (params.role) queryParams.set('role', params.role);
+  queryParams.set('sortBy', field);
+  queryParams.set('sortOrder', nextOrder);
+  queryParams.set('page', '1');
+
+  return (
+    <Link
+      href={`/sales?${queryParams.toString()}`}
+      className="flex items-center gap-1 hover:text-foreground"
+    >
+      {label}
+      {isActive && (
+        <span className="text-xs">{currentOrder === 'desc' ? '▼' : '▲'}</span>
+      )}
+    </Link>
+  );
+}
+
+/**
+ * ページネーションコンポーネント
+ */
+function Pagination({
+  currentPage,
+  totalPages,
+  params,
+}: {
+  currentPage: number;
+  totalPages: number;
+  params: SearchParams;
+}) {
+  const buildPageUrl = (page: number) => {
+    const queryParams = new URLSearchParams();
+    if (params.salesName) queryParams.set('salesName', params.salesName);
+    if (params.department) queryParams.set('department', params.department);
+    if (params.role) queryParams.set('role', params.role);
+    if (params.sortBy) queryParams.set('sortBy', params.sortBy);
+    if (params.sortOrder) queryParams.set('sortOrder', params.sortOrder);
+    queryParams.set('page', page.toString());
+    return `/sales?${queryParams.toString()}`;
+  };
+
+  // 表示するページ番号を計算
+  const getPageNumbers = () => {
+    const pages: number[] = [];
+    const maxPagesToShow = 5;
+    let startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
+    const endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+
+    if (endPage - startPage < maxPagesToShow - 1) {
+      startPage = Math.max(1, endPage - maxPagesToShow + 1);
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+    return pages;
+  };
+
+  return (
+    <div className="mt-4 flex items-center justify-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={currentPage === 1}
+        asChild={currentPage !== 1}
+      >
+        {currentPage === 1 ? (
+          <span>前へ</span>
+        ) : (
+          <Link href={buildPageUrl(currentPage - 1)}>前へ</Link>
+        )}
+      </Button>
+
+      {getPageNumbers().map((pageNum) => (
+        <Button
+          key={pageNum}
+          variant={pageNum === currentPage ? 'default' : 'outline'}
+          size="sm"
+          asChild={pageNum !== currentPage}
+        >
+          {pageNum === currentPage ? (
+            <span>{pageNum}</span>
+          ) : (
+            <Link href={buildPageUrl(pageNum)}>{pageNum}</Link>
+          )}
+        </Button>
+      ))}
+
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={currentPage === totalPages}
+        asChild={currentPage !== totalPages}
+      >
+        {currentPage === totalPages ? (
+          <span>次へ</span>
+        ) : (
+          <Link href={buildPageUrl(currentPage + 1)}>次へ</Link>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sales/sales-filters.tsx
+++ b/src/app/(dashboard)/sales/sales-filters.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface FilterOption {
+  value: string;
+  label: string;
+}
+
+interface SalesFiltersProps {
+  salesName: string;
+  department: string;
+  role: string;
+  departmentOptions: readonly FilterOption[];
+  roleOptions: readonly FilterOption[];
+}
+
+/**
+ * 営業マスタ一覧のフィルタコンポーネント（Client Component）
+ */
+export function SalesFilters({
+  salesName: initialSalesName,
+  department: initialDepartment,
+  role: initialRole,
+  departmentOptions,
+  roleOptions,
+}: SalesFiltersProps) {
+  const router = useRouter();
+
+  // フォーム状態
+  const [salesName, setSalesName] = useState(initialSalesName);
+  const [department, setDepartment] = useState(initialDepartment);
+  const [role, setRole] = useState(initialRole);
+
+  // 検索実行
+  const handleSearch = useCallback(() => {
+    const params = new URLSearchParams();
+
+    if (salesName) {
+      params.set('salesName', salesName);
+    }
+    // '_all' は「すべて」を表す内部値なので、パラメータには含めない
+    if (department && department !== '_all') {
+      params.set('department', department);
+    }
+    if (role && role !== '_all') {
+      params.set('role', role);
+    }
+    params.set('page', '1');
+
+    router.push(`/sales?${params.toString()}`);
+  }, [salesName, department, role, router]);
+
+  // クリア
+  const handleClear = useCallback(() => {
+    setSalesName('');
+    setDepartment('');
+    setRole('');
+    router.push('/sales');
+  }, [router]);
+
+  // Enterキーで検索実行
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        handleSearch();
+      }
+    },
+    [handleSearch]
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {/* 担当者名 */}
+        <div className="space-y-2">
+          <Label htmlFor="salesName">担当者名</Label>
+          <Input
+            id="salesName"
+            type="text"
+            placeholder="担当者名で検索"
+            value={salesName}
+            onChange={(e) => setSalesName(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+        </div>
+
+        {/* 部署 */}
+        <div className="space-y-2">
+          <Label htmlFor="department">部署</Label>
+          <Select value={department || '_all'} onValueChange={setDepartment}>
+            <SelectTrigger id="department" className="w-full">
+              <SelectValue placeholder="すべて" />
+            </SelectTrigger>
+            <SelectContent>
+              {departmentOptions.map((option) => (
+                <SelectItem
+                  key={option.value || '_all'}
+                  value={option.value || '_all'}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* 役割 */}
+        <div className="space-y-2">
+          <Label htmlFor="role">役割</Label>
+          <Select value={role || '_all'} onValueChange={setRole}>
+            <SelectTrigger id="role" className="w-full">
+              <SelectValue placeholder="すべて" />
+            </SelectTrigger>
+            <SelectContent>
+              {roleOptions.map((option) => (
+                <SelectItem
+                  key={option.value || '_all'}
+                  value={option.value || '_all'}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* ボタン */}
+      <div className="flex gap-2">
+        <Button onClick={handleSearch}>検索</Button>
+        <Button variant="outline" onClick={handleClear}>
+          クリア
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/sales/[id]/route.ts
+++ b/src/app/api/sales/[id]/route.ts
@@ -1,0 +1,343 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { updateSalesSchema } from '@/lib/validations/sales';
+import { ROLES } from '@/lib/constants';
+
+/**
+ * 営業担当者詳細取得API
+ * GET /api/sales/[id]
+ *
+ * 指定されたIDの営業担当者情報を取得します。
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    // 権限チェック（上長のみアクセス可）
+    const userRole = (session.user as any).role;
+    if (userRole !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: 'この操作には上長権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const params = await context.params;
+    const salesId = parseInt(params.id, 10);
+
+    if (isNaN(salesId)) {
+      return NextResponse.json(
+        { error: '無効な営業担当者IDです' },
+        { status: 400 }
+      );
+    }
+
+    // 営業担当者情報を取得
+    const sales = await prisma.sales.findUnique({
+      where: { salesId },
+      select: {
+        salesId: true,
+        salesName: true,
+        email: true,
+        department: true,
+        role: true,
+        managerId: true,
+        manager: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!sales) {
+      return NextResponse.json(
+        { error: '営業担当者が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      data: {
+        salesId: sales.salesId,
+        salesName: sales.salesName,
+        email: sales.email,
+        department: sales.department,
+        role: sales.role,
+        managerId: sales.managerId,
+        managerName: sales.manager?.salesName || null,
+        createdAt: sales.createdAt,
+        updatedAt: sales.updatedAt,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to fetch sales:', error);
+    return NextResponse.json(
+      { error: '営業担当者情報の取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * 営業担当者更新API
+ * PUT /api/sales/[id]
+ *
+ * 指定されたIDの営業担当者情報を更新します。上長のみアクセス可能。
+ */
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    // 権限チェック（上長のみアクセス可）
+    const userRole = (session.user as any).role;
+    if (userRole !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: 'この操作には上長権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const params = await context.params;
+    const salesId = parseInt(params.id, 10);
+
+    if (isNaN(salesId)) {
+      return NextResponse.json(
+        { error: '無効な営業担当者IDです' },
+        { status: 400 }
+      );
+    }
+
+    // 営業担当者の存在確認
+    const existingSales = await prisma.sales.findUnique({
+      where: { salesId },
+    });
+
+    if (!existingSales) {
+      return NextResponse.json(
+        { error: '営業担当者が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // リクエストボディを取得
+    const body = await request.json();
+
+    // バリデーション
+    const validation = updateSalesSchema.safeParse(body);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors[0]?.message;
+      return NextResponse.json(
+        { error: errorMessage || '入力内容に誤りがあります' },
+        { status: 400 }
+      );
+    }
+
+    const data = validation.data;
+
+    // メールアドレスの重複チェック（自分以外）
+    const existingEmail = await prisma.sales.findFirst({
+      where: {
+        email: data.email,
+        NOT: { salesId },
+      },
+    });
+
+    if (existingEmail) {
+      return NextResponse.json(
+        { error: 'このメールアドレスは既に登録されています' },
+        { status: 409 }
+      );
+    }
+
+    // 上長IDが指定されている場合、存在確認
+    if (data.managerId) {
+      // 自分自身を上長には設定できない
+      if (data.managerId === salesId) {
+        return NextResponse.json(
+          { error: '自分自身を上長として設定することはできません' },
+          { status: 400 }
+        );
+      }
+
+      const manager = await prisma.sales.findUnique({
+        where: { salesId: data.managerId },
+      });
+
+      if (!manager) {
+        return NextResponse.json(
+          { error: '指定された上長が見つかりません' },
+          { status: 400 }
+        );
+      }
+
+      // 上長は「上長」ロールでなければならない
+      if (manager.role !== ROLES.MANAGER) {
+        return NextResponse.json(
+          { error: '指定されたユーザーは上長ではありません' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // 営業担当者情報を更新
+    const sales = await prisma.sales.update({
+      where: { salesId },
+      data: {
+        salesName: data.salesName,
+        email: data.email,
+        department: data.department,
+        role: data.role,
+        managerId: data.managerId || null,
+      },
+      select: {
+        salesId: true,
+        salesName: true,
+        email: true,
+        department: true,
+        role: true,
+        managerId: true,
+        manager: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return NextResponse.json({
+      data: {
+        salesId: sales.salesId,
+        salesName: sales.salesName,
+        email: sales.email,
+        department: sales.department,
+        role: sales.role,
+        managerId: sales.managerId,
+        managerName: sales.manager?.salesName || null,
+        createdAt: sales.createdAt,
+        updatedAt: sales.updatedAt,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to update sales:', error);
+    return NextResponse.json(
+      { error: '営業担当者情報の更新に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * 営業担当者削除API
+ * DELETE /api/sales/[id]
+ *
+ * 指定されたIDの営業担当者を削除します。上長のみアクセス可能。
+ * 日報が存在する場合は削除できません。
+ */
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    // 権限チェック（上長のみアクセス可）
+    const userRole = (session.user as any).role;
+    if (userRole !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: 'この操作には上長権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const params = await context.params;
+    const salesId = parseInt(params.id, 10);
+
+    if (isNaN(salesId)) {
+      return NextResponse.json(
+        { error: '無効な営業担当者IDです' },
+        { status: 400 }
+      );
+    }
+
+    // 自分自身を削除することはできない
+    const currentUserId = (session.user as any).salesId;
+    if (salesId === currentUserId) {
+      return NextResponse.json(
+        { error: '自分自身を削除することはできません' },
+        { status: 400 }
+      );
+    }
+
+    // 営業担当者の存在確認
+    const existingSales = await prisma.sales.findUnique({
+      where: { salesId },
+      include: {
+        dailyReports: true,
+        subordinates: true,
+      },
+    });
+
+    if (!existingSales) {
+      return NextResponse.json(
+        { error: '営業担当者が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 日報が紐づいている場合は削除不可
+    if (existingSales.dailyReports.length > 0) {
+      return NextResponse.json(
+        { error: 'この営業担当者は日報が存在するため削除できません' },
+        { status: 409 }
+      );
+    }
+
+    // 部下がいる場合は削除不可
+    if (existingSales.subordinates.length > 0) {
+      return NextResponse.json(
+        { error: 'この営業担当者には部下が存在するため削除できません' },
+        { status: 409 }
+      );
+    }
+
+    // 営業担当者を削除
+    await prisma.sales.delete({
+      where: { salesId },
+    });
+
+    return NextResponse.json({ message: '営業担当者を削除しました' });
+  } catch (error) {
+    console.error('Failed to delete sales:', error);
+    return NextResponse.json(
+      { error: '営業担当者の削除に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/sales/route.ts
+++ b/src/app/api/sales/route.ts
@@ -1,0 +1,242 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import bcrypt from 'bcryptjs';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { createSalesSchema } from '@/lib/validations/sales';
+import { ROLES } from '@/lib/constants';
+
+/**
+ * 営業担当者一覧取得API
+ * GET /api/sales
+ *
+ * 上長のみがアクセス可能な営業担当者の一覧を取得します。
+ * クエリパラメータでフィルタリング・ソートが可能です。
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    // 権限チェック（上長のみアクセス可）
+    const userRole = (session.user as any).role;
+    if (userRole !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: 'この操作には上長権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const salesName = searchParams.get('salesName') || '';
+    const department = searchParams.get('department') || '';
+    const role = searchParams.get('role') || '';
+    const sortBy = searchParams.get('sortBy') || 'salesName';
+    const sortOrder = searchParams.get('sortOrder') || 'asc';
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const limit = parseInt(searchParams.get('limit') || '100', 10);
+
+    // 検索条件の構築
+    const where = {
+      ...(salesName && {
+        salesName: { contains: salesName },
+      }),
+      ...(department && {
+        department: { contains: department },
+      }),
+      ...(role && { role }),
+    };
+
+    // ソート条件の構築
+    const orderBy: Record<string, 'asc' | 'desc'> = {
+      [sortBy]: sortOrder as 'asc' | 'desc',
+    };
+
+    // データ取得
+    const [salesList, totalCount] = await Promise.all([
+      prisma.sales.findMany({
+        where,
+        select: {
+          salesId: true,
+          salesName: true,
+          email: true,
+          department: true,
+          role: true,
+          managerId: true,
+          manager: {
+            select: {
+              salesId: true,
+              salesName: true,
+            },
+          },
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      prisma.sales.count({ where }),
+    ]);
+
+    // レスポンス形式を整形
+    const formattedSales = salesList.map((sales) => ({
+      salesId: sales.salesId,
+      salesName: sales.salesName,
+      email: sales.email,
+      department: sales.department,
+      role: sales.role,
+      managerId: sales.managerId,
+      managerName: sales.manager?.salesName || null,
+      createdAt: sales.createdAt,
+      updatedAt: sales.updatedAt,
+    }));
+
+    return NextResponse.json({
+      data: formattedSales,
+      pagination: {
+        page,
+        limit,
+        totalCount,
+        totalPages: Math.ceil(totalCount / limit),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to fetch sales list:', error);
+    return NextResponse.json(
+      { error: '営業担当者一覧の取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * 営業担当者作成API
+ * POST /api/sales
+ *
+ * 新しい営業担当者を作成します。上長のみアクセス可能。
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    // 権限チェック（上長のみアクセス可）
+    const userRole = (session.user as any).role;
+    if (userRole !== ROLES.MANAGER) {
+      return NextResponse.json(
+        { error: 'この操作には上長権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    // リクエストボディを取得
+    const body = await request.json();
+
+    // バリデーション
+    const validation = createSalesSchema.safeParse(body);
+    if (!validation.success) {
+      const errorMessage = validation.error.errors[0]?.message;
+      return NextResponse.json(
+        { error: errorMessage || '入力内容に誤りがあります' },
+        { status: 400 }
+      );
+    }
+
+    const data = validation.data;
+
+    // メールアドレスの重複チェック
+    const existingEmail = await prisma.sales.findUnique({
+      where: { email: data.email },
+    });
+
+    if (existingEmail) {
+      return NextResponse.json(
+        { error: 'このメールアドレスは既に登録されています' },
+        { status: 409 }
+      );
+    }
+
+    // 上長IDが指定されている場合、存在確認
+    if (data.managerId) {
+      const manager = await prisma.sales.findUnique({
+        where: { salesId: data.managerId },
+      });
+
+      if (!manager) {
+        return NextResponse.json(
+          { error: '指定された上長が見つかりません' },
+          { status: 400 }
+        );
+      }
+
+      // 上長は「上長」ロールでなければならない
+      if (manager.role !== ROLES.MANAGER) {
+        return NextResponse.json(
+          { error: '指定されたユーザーは上長ではありません' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // パスワードをハッシュ化
+    const hashedPassword = await bcrypt.hash(data.password, 10);
+
+    // 営業担当者を作成
+    const sales = await prisma.sales.create({
+      data: {
+        salesName: data.salesName,
+        email: data.email,
+        password: hashedPassword,
+        department: data.department,
+        role: data.role,
+        managerId: data.managerId || null,
+      },
+      select: {
+        salesId: true,
+        salesName: true,
+        email: true,
+        department: true,
+        role: true,
+        managerId: true,
+        manager: {
+          select: {
+            salesId: true,
+            salesName: true,
+          },
+        },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        data: {
+          salesId: sales.salesId,
+          salesName: sales.salesName,
+          email: sales.email,
+          department: sales.department,
+          role: sales.role,
+          managerId: sales.managerId,
+          managerName: sales.manager?.salesName || null,
+          createdAt: sales.createdAt,
+          updatedAt: sales.updatedAt,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('Failed to create sales:', error);
+    return NextResponse.json(
+      { error: '営業担当者の作成に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/features/sales/SalesForm.tsx
+++ b/src/components/features/sales/SalesForm.tsx
@@ -1,0 +1,443 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ROLES, type Role } from '@/lib/constants';
+
+// フォームのバリデーションスキーマ
+const salesFormSchema = z.object({
+  salesName: z
+    .string()
+    .min(1, '営業担当者名を入力してください。')
+    .max(100, '営業担当者名は100文字以内で入力してください。'),
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください。')
+    .email('メールアドレスの形式が正しくありません。')
+    .max(255, 'メールアドレスは255文字以内で入力してください。'),
+  password: z.string().optional(),
+  department: z
+    .string()
+    .min(1, '所属部署を入力してください。')
+    .max(100, '所属部署は100文字以内で入力してください。'),
+  role: z.enum([ROLES.MANAGER, ROLES.SALES], {
+    errorMap: () => ({ message: '役割を選択してください。' }),
+  }),
+  managerId: z.string().optional(),
+});
+
+type SalesFormInput = z.infer<typeof salesFormSchema>;
+
+interface Manager {
+  salesId: number;
+  salesName: string;
+}
+
+interface SalesFormProps {
+  mode: 'create' | 'edit';
+  salesId?: number;
+  initialData?: {
+    salesName: string;
+    email: string;
+    department: string;
+    role: Role;
+    managerId: number | null;
+  };
+}
+
+/**
+ * 営業担当者フォームコンポーネント
+ *
+ * 営業マスタの登録・編集を行うフォーム
+ * - 営業担当者名の入力（必須）
+ * - メールアドレスの入力（必須）
+ * - パスワードの入力（新規登録時のみ必須）
+ * - 所属部署の入力（必須）
+ * - 役割の選択（必須）
+ * - 上長の選択（任意）
+ */
+export function SalesForm({ mode, salesId, initialData }: SalesFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [managers, setManagers] = useState<Manager[]>([]);
+  const [isLoadingManagers, setIsLoadingManagers] = useState(true);
+
+  const form = useForm<SalesFormInput>({
+    resolver: zodResolver(salesFormSchema),
+    defaultValues: initialData
+      ? {
+          salesName: initialData.salesName,
+          email: initialData.email,
+          password: '',
+          department: initialData.department,
+          role: initialData.role,
+          managerId: initialData.managerId?.toString() || '',
+        }
+      : {
+          salesName: '',
+          email: '',
+          password: '',
+          department: '',
+          role: ROLES.SALES,
+          managerId: '',
+        },
+  });
+
+  // 上長一覧を取得
+  useEffect(() => {
+    const fetchManagers = async () => {
+      try {
+        const response = await fetch('/api/sales?role=' + ROLES.MANAGER);
+        if (response.ok) {
+          const result = await response.json();
+          // 編集時は自分自身を除外
+          const filteredManagers = result.data.filter(
+            (m: Manager & { role: string }) =>
+              m.role === ROLES.MANAGER && m.salesId !== salesId
+          );
+          setManagers(filteredManagers);
+        }
+      } catch (err) {
+        console.error('Failed to fetch managers:', err);
+      } finally {
+        setIsLoadingManagers(false);
+      }
+    };
+
+    fetchManagers();
+  }, [salesId]);
+
+  /**
+   * フォーム送信処理
+   */
+  const onSubmit = async (data: SalesFormInput) => {
+    setError(null);
+
+    // 新規作成時はパスワード必須
+    if (mode === 'create' && (!data.password || data.password.length < 8)) {
+      form.setError('password', {
+        type: 'manual',
+        message: 'パスワードは8文字以上で入力してください。',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const url = mode === 'create' ? '/api/sales' : `/api/sales/${salesId}`;
+      const method = mode === 'create' ? 'POST' : 'PUT';
+
+      const requestBody: Record<string, unknown> = {
+        salesName: data.salesName,
+        email: data.email,
+        department: data.department,
+        role: data.role,
+        managerId: data.managerId ? parseInt(data.managerId, 10) : null,
+      };
+
+      // 新規作成時のみパスワードを含める
+      if (mode === 'create') {
+        requestBody.password = data.password;
+      }
+
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      const responseData = await response.json();
+
+      if (!response.ok) {
+        throw new Error(
+          responseData.error ||
+            `営業担当者の${mode === 'create' ? '登録' : '更新'}に失敗しました`
+        );
+      }
+
+      router.push('/sales');
+      router.refresh();
+    } catch (err) {
+      console.error(`Failed to ${mode} sales:`, err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : `営業担当者の${mode === 'create' ? '登録' : '更新'}に失敗しました`
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * キャンセル処理
+   */
+  const handleCancel = () => {
+    router.push('/sales');
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* エラーメッセージ */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          {/* 基本情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle>基本情報</CardTitle>
+              <CardDescription>
+                営業担当者の基本情報を入力してください
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* 営業担当者名 */}
+              <FormField
+                control={form.control}
+                name="salesName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      営業担当者名 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="山田 太郎"
+                        maxLength={100}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* メールアドレス */}
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      メールアドレス <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="yamada@example.com"
+                        maxLength={255}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* パスワード（新規登録時のみ必須） */}
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      パスワード{' '}
+                      {mode === 'create' && (
+                        <span className="text-destructive">*</span>
+                      )}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        placeholder={
+                          mode === 'edit' ? '変更しない場合は空欄' : '8文字以上'
+                        }
+                        maxLength={255}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                    {mode === 'edit' && (
+                      <p className="text-xs text-muted-foreground">
+                        ※ パスワードの変更は別途管理機能から行ってください
+                      </p>
+                    )}
+                  </FormItem>
+                )}
+              />
+
+              {/* 所属部署 */}
+              <FormField
+                control={form.control}
+                name="department"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      所属部署 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="営業1部"
+                        maxLength={100}
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          {/* 権限情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle>権限情報</CardTitle>
+              <CardDescription>役割と上長を設定してください</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* 役割 */}
+              <FormField
+                control={form.control}
+                name="role"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      役割 <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="役割を選択してください" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value={ROLES.SALES}>
+                          {ROLES.SALES}
+                        </SelectItem>
+                        <SelectItem value={ROLES.MANAGER}>
+                          {ROLES.MANAGER}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* 上長 */}
+              <FormField
+                control={form.control}
+                name="managerId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>上長</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value || '_none'}
+                      disabled={isSubmitting || isLoadingManagers}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue
+                            placeholder={
+                              isLoadingManagers
+                                ? '読み込み中...'
+                                : '上長を選択してください'
+                            }
+                          />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="_none">なし</SelectItem>
+                        {managers.map((manager) => (
+                          <SelectItem
+                            key={manager.salesId}
+                            value={manager.salesId.toString()}
+                          >
+                            {manager.salesName}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                    <p className="text-xs text-muted-foreground">
+                      ※
+                      上長として選択できるのは「上長」の役割を持つユーザーのみです
+                    </p>
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          {/* 送信ボタン */}
+          <div className="flex justify-end gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting
+                ? mode === 'create'
+                  ? '登録中...'
+                  : '更新中...'
+                : mode === 'create'
+                  ? '登録'
+                  : '更新'}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/lib/validations/sales.ts
+++ b/src/lib/validations/sales.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import { ROLES } from '@/lib/constants';
+
+/**
+ * 営業担当者フォームのバリデーションスキーマ
+ */
+export const salesFormSchema = z
+  .object({
+    salesName: z
+      .string()
+      .min(1, '営業担当者名を入力してください。')
+      .max(100, '営業担当者名は100文字以内で入力してください。'),
+    email: z
+      .string()
+      .min(1, 'メールアドレスを入力してください。')
+      .email('メールアドレスの形式が正しくありません。')
+      .max(255, 'メールアドレスは255文字以内で入力してください。'),
+    password: z
+      .string()
+      .min(8, 'パスワードは8文字以上で入力してください。')
+      .max(255, 'パスワードは255文字以内で入力してください。')
+      .optional()
+      .or(z.literal('')),
+    department: z
+      .string()
+      .min(1, '所属部署を入力してください。')
+      .max(100, '所属部署は100文字以内で入力してください。'),
+    role: z.enum([ROLES.MANAGER, ROLES.SALES], {
+      errorMap: () => ({ message: '役割を選択してください。' }),
+    }),
+    managerId: z.number().int().positive().optional().nullable(),
+  })
+  .refine(
+    () => {
+      // 新規作成時（passwordが必須）の場合のみチェック
+      // 編集時はpasswordは省略可能なので、呼び出し側で制御
+      return true;
+    },
+    {
+      message: 'パスワードを入力してください。',
+      path: ['password'],
+    }
+  );
+
+/**
+ * 営業担当者作成APIリクエストのバリデーションスキーマ
+ */
+export const createSalesSchema = z.object({
+  salesName: z
+    .string()
+    .min(1, '営業担当者名を入力してください。')
+    .max(100, '営業担当者名は100文字以内で入力してください。'),
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください。')
+    .email('メールアドレスの形式が正しくありません。')
+    .max(255, 'メールアドレスは255文字以内で入力してください。'),
+  password: z
+    .string()
+    .min(8, 'パスワードは8文字以上で入力してください。')
+    .max(255, 'パスワードは255文字以内で入力してください。'),
+  department: z
+    .string()
+    .min(1, '所属部署を入力してください。')
+    .max(100, '所属部署は100文字以内で入力してください。'),
+  role: z.enum([ROLES.MANAGER, ROLES.SALES], {
+    errorMap: () => ({ message: '役割を選択してください。' }),
+  }),
+  managerId: z.number().int().positive().optional().nullable(),
+});
+
+/**
+ * 営業担当者更新APIリクエストのバリデーションスキーマ
+ * パスワードは任意
+ */
+export const updateSalesSchema = z.object({
+  salesName: z
+    .string()
+    .min(1, '営業担当者名を入力してください。')
+    .max(100, '営業担当者名は100文字以内で入力してください。'),
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください。')
+    .email('メールアドレスの形式が正しくありません。')
+    .max(255, 'メールアドレスは255文字以内で入力してください。'),
+  department: z
+    .string()
+    .min(1, '所属部署を入力してください。')
+    .max(100, '所属部署は100文字以内で入力してください。'),
+  role: z.enum([ROLES.MANAGER, ROLES.SALES], {
+    errorMap: () => ({ message: '役割を選択してください。' }),
+  }),
+  managerId: z.number().int().positive().optional().nullable(),
+});
+
+/**
+ * 型定義
+ */
+export type SalesFormInput = z.infer<typeof salesFormSchema>;
+export type CreateSalesInput = z.infer<typeof createSalesSchema>;
+export type UpdateSalesInput = z.infer<typeof updateSalesSchema>;


### PR DESCRIPTION
## Summary
- 営業マスタ一覧画面（S-008）の実装
  - 営業担当者の一覧表示、検索フィルタ、ソート、ページネーション
  - 上長のみアクセス可能な権限制御
- 営業マスタ登録/編集画面（S-009）の実装
  - 新規登録・編集フォーム、バリデーション
- 営業担当者API（CRUD）の実装
  - GET/POST /api/sales, GET/PUT/DELETE /api/sales/:id

## Test plan
- [ ] 上長ユーザーでログインし、営業マスタ一覧画面にアクセスできること
- [ ] 一般営業ユーザーでは営業マスタ一覧にアクセスできないこと（ダッシュボードへリダイレクト）
- [ ] 営業担当者の検索（担当者名、部署、役割）が機能すること
- [ ] 新規営業担当者を登録できること
- [ ] 既存営業担当者の情報を編集できること
- [ ] バリデーションが正しく動作すること
- [ ] `npm run lint` と `npm run type-check` が通ること
- [ ] `npm run test` が通ること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)