### PR TITLE
feat: Issue #16 訪問記録APIエンドポイントの実装

### DIFF
--- a/src/app/api/reports/[id]/visits/route.ts
+++ b/src/app/api/reports/[id]/visits/route.ts
@@ -105,7 +105,7 @@ export async function GET(
       customer_id: visit.customer.customerId,
       customer_name: visit.customer.customerName,
       company_name: visit.customer.companyName,
-      visit_time: visit.visitTime.toISOString().substring(11, 16), // "HH:MM" format
+      visit_time: visit.visitTime.toISOString().substring(11, 19), // "HH:MM:SS" format
       visit_content: visit.visitContent,
       created_at: visit.createdAt.toISOString(),
       updated_at: visit.updatedAt.toISOString(),
@@ -151,8 +151,15 @@ export async function POST(
 
     const body = await request.json();
 
+    // snake_case → camelCase 変換（API仕様書との互換性）
+    const normalizedBody = {
+      visitTime: body.visit_time ?? body.visitTime,
+      customerId: body.customer_id ?? body.customerId,
+      visitContent: body.visit_content ?? body.visitContent,
+    };
+
     // バリデーション
-    const validation = visitSchema.safeParse(body);
+    const validation = visitSchema.safeParse(normalizedBody);
     if (!validation.success) {
       const errorMessage = validation.error.errors[0]?.message;
       return NextResponse.json(
@@ -257,7 +264,7 @@ export async function POST(
       customer_id: visit.customer.customerId,
       customer_name: visit.customer.customerName,
       company_name: visit.customer.companyName,
-      visit_time: visit.visitTime.toISOString().substring(11, 16),
+      visit_time: visit.visitTime.toISOString().substring(11, 19),
       visit_content: visit.visitContent,
       created_at: visit.createdAt.toISOString(),
       updated_at: visit.updatedAt.toISOString(),

--- a/src/app/api/visits/[id]/route.ts
+++ b/src/app/api/visits/[id]/route.ts
@@ -38,8 +38,15 @@ export async function PUT(
 
     const body = await request.json();
 
+    // snake_case → camelCase 変換（API仕様書との互換性）
+    const normalizedBody = {
+      visitTime: body.visit_time ?? body.visitTime,
+      customerId: body.customer_id ?? body.customerId,
+      visitContent: body.visit_content ?? body.visitContent,
+    };
+
     // バリデーション
-    const validation = visitSchema.safeParse(body);
+    const validation = visitSchema.safeParse(normalizedBody);
     if (!validation.success) {
       const errorMessage = validation.error.errors[0]?.message;
       return NextResponse.json(
@@ -148,7 +155,7 @@ export async function PUT(
       customer_id: updatedVisit.customer.customerId,
       customer_name: updatedVisit.customer.customerName,
       company_name: updatedVisit.customer.companyName,
-      visit_time: updatedVisit.visitTime.toISOString().substring(11, 16),
+      visit_time: updatedVisit.visitTime.toISOString().substring(11, 19),
       visit_content: updatedVisit.visitContent,
       created_at: updatedVisit.createdAt.toISOString(),
       updated_at: updatedVisit.updatedAt.toISOString(),


### PR DESCRIPTION
## Summary
- 訪問記録関連のAPIエンドポイント（GET/POST/PUT/DELETE）を実装
- Zodによるバリデーション、権限チェック、ステータスチェックを実装
- 日報との関連チェック、顧客存在チェックを実装

## 実装内容
- `GET /api/reports/:report_id/visits` - 訪問記録一覧取得
- `POST /api/reports/:report_id/visits` - 訪問記録作成
- `PUT /api/visits/:id` - 訪問記録更新
- `DELETE /api/visits/:id` - 訪問記録削除

## Closes
Closes #16

## Test plan
- [ ] 訪問記録一覧取得APIの動作確認
- [ ] 訪問記録作成APIの動作確認（バリデーション含む）
- [ ] 訪問記録更新APIの動作確認
- [ ] 訪問記録削除APIの動作確認
- [ ] 権限チェックの動作確認（一般営業/上長）
- [ ] ステータスチェックの動作確認（下書き/差し戻し以外で編集不可）
- [ ] 顧客存在チェックの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)