### PR TITLE
feat: Issue #23 ユーティリティ関数・ヘルパー関数の実装

### DIFF
--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,0 +1,315 @@
+/**
+ * API応答ヘルパー関数
+ */
+
+import { NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import {
+  AppError,
+  getErrorMessage,
+  getErrorStatusCode,
+  getErrorCode,
+  fromZodError,
+  formatErrorForLog,
+} from './error';
+
+/**
+ * 成功レスポンスの型
+ */
+export interface ApiSuccessResponse<T = unknown> {
+  success: true;
+  data: T;
+  message?: string;
+}
+
+/**
+ * エラーレスポンスの型
+ */
+export interface ApiErrorResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, string[]>;
+  };
+}
+
+/**
+ * ページネーション情報
+ */
+export interface PaginationMeta {
+  page: number;
+  perPage: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * リストレスポンスの型
+ */
+export interface ApiListResponse<T = unknown> {
+  success: true;
+  data: T[];
+  pagination: PaginationMeta;
+}
+
+/**
+ * 成功レスポンスを作成
+ */
+export function createSuccessResponse<T>(
+  data: T,
+  message?: string,
+  status: number = 200
+): NextResponse<ApiSuccessResponse<T>> {
+  return NextResponse.json(
+    {
+      success: true as const,
+      data,
+      message,
+    },
+    { status }
+  );
+}
+
+/**
+ * リストレスポンスを作成
+ */
+export function createListResponse<T>(
+  data: T[],
+  pagination: PaginationMeta,
+  status: number = 200
+): NextResponse<ApiListResponse<T>> {
+  return NextResponse.json(
+    {
+      success: true as const,
+      data,
+      pagination,
+    },
+    { status }
+  );
+}
+
+/**
+ * 作成成功レスポンスを作成
+ */
+export function createCreatedResponse<T>(
+  data: T,
+  message: string = '作成しました'
+): NextResponse<ApiSuccessResponse<T>> {
+  return createSuccessResponse(data, message, 201);
+}
+
+/**
+ * 削除成功レスポンスを作成
+ */
+export function createDeletedResponse(
+  message: string = '削除しました'
+): NextResponse<ApiSuccessResponse<null>> {
+  return createSuccessResponse(null, message, 200);
+}
+
+/**
+ * エラーレスポンスを作成
+ */
+export function createErrorResponse(
+  error: unknown
+): NextResponse<ApiErrorResponse> {
+  const statusCode = getErrorStatusCode(error);
+  const message = getErrorMessage(error);
+  const code = getErrorCode(error);
+
+  // 開発環境ではエラーをログに出力
+  if (process.env.NODE_ENV === 'development') {
+    console.error('API Error:', formatErrorForLog(error));
+  }
+
+  // ValidationErrorの場合は詳細情報を含める
+  if (error instanceof ZodError) {
+    const validationError = fromZodError(error);
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          code,
+          message,
+          details: validationError.errors,
+        },
+      },
+      { status: statusCode }
+    );
+  }
+
+  if (error instanceof AppError && 'errors' in error) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          code,
+          message,
+          details: (error as AppError & { errors: Record<string, string[]> })
+            .errors,
+        },
+      },
+      { status: statusCode }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      success: false as const,
+      error: {
+        code,
+        message,
+      },
+    },
+    { status: statusCode }
+  );
+}
+
+/**
+ * 認証エラーレスポンスを作成
+ */
+export function createUnauthorizedResponse(
+  message: string = '認証が必要です'
+): NextResponse<ApiErrorResponse> {
+  return NextResponse.json(
+    {
+      success: false as const,
+      error: {
+        code: 'AUTHENTICATION_REQUIRED',
+        message,
+      },
+    },
+    { status: 401 }
+  );
+}
+
+/**
+ * 認可エラーレスポンスを作成
+ */
+export function createForbiddenResponse(
+  message: string = 'この操作を行う権限がありません'
+): NextResponse<ApiErrorResponse> {
+  return NextResponse.json(
+    {
+      success: false as const,
+      error: {
+        code: 'FORBIDDEN',
+        message,
+      },
+    },
+    { status: 403 }
+  );
+}
+
+/**
+ * Not Foundレスポンスを作成
+ */
+export function createNotFoundResponse(
+  resource: string = 'リソース'
+): NextResponse<ApiErrorResponse> {
+  return NextResponse.json(
+    {
+      success: false as const,
+      error: {
+        code: 'NOT_FOUND',
+        message: `${resource}が見つかりません`,
+      },
+    },
+    { status: 404 }
+  );
+}
+
+/**
+ * バリデーションエラーレスポンスを作成
+ */
+export function createValidationErrorResponse(
+  message: string = '入力内容に誤りがあります',
+  details?: Record<string, string[]>
+): NextResponse<ApiErrorResponse> {
+  return NextResponse.json(
+    {
+      success: false as const,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message,
+        details,
+      },
+    },
+    { status: 400 }
+  );
+}
+
+/**
+ * ページネーション情報を計算
+ */
+export function calculatePagination(
+  total: number,
+  page: number,
+  perPage: number
+): PaginationMeta {
+  return {
+    page,
+    perPage,
+    total,
+    totalPages: Math.ceil(total / perPage),
+  };
+}
+
+/**
+ * リクエストボディをパースしてバリデーション
+ */
+export async function parseRequestBody<T>(
+  request: Request,
+  schema: { parse: (data: unknown) => T }
+): Promise<T> {
+  const body = await request.json();
+  return schema.parse(body);
+}
+
+/**
+ * URLパラメータからIDを取得
+ */
+export function getIdFromParams(params: { id?: string }): number {
+  const id = params.id;
+  if (!id) {
+    throw new AppError('IDが指定されていません', 400, 'MISSING_ID');
+  }
+  const numericId = parseInt(id, 10);
+  if (isNaN(numericId) || numericId <= 0) {
+    throw new AppError('無効なIDです', 400, 'INVALID_ID');
+  }
+  return numericId;
+}
+
+/**
+ * クエリパラメータを取得
+ */
+export function getQueryParams(
+  request: Request
+): Record<string, string | undefined> {
+  const url = new URL(request.url);
+  const params: Record<string, string | undefined> = {};
+  url.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return params;
+}
+
+/**
+ * ページネーションパラメータを取得
+ */
+export function getPaginationParams(request: Request): {
+  page: number;
+  perPage: number;
+  skip: number;
+} {
+  const params = getQueryParams(request);
+  const page = Math.max(1, parseInt(params.page ?? '1', 10) || 1);
+  const perPage = Math.min(
+    100,
+    Math.max(1, parseInt(params.perPage ?? '20', 10) || 20)
+  );
+  const skip = (page - 1) * perPage;
+  return { page, perPage, skip };
+}

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,0 +1,148 @@
+/**
+ * 日付関連のユーティリティ関数
+ */
+
+/**
+ * JST (Asia/Tokyo) タイムゾーンオフセット（ミリ秒）
+ */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * JSTでの今日の日付を取得（時刻は00:00:00）
+ */
+export function getTodayJST(): Date {
+  const now = new Date();
+  const utcTime = now.getTime() + now.getTimezoneOffset() * 60 * 1000;
+  const jstTime = new Date(utcTime + JST_OFFSET_MS);
+  return new Date(jstTime.getFullYear(), jstTime.getMonth(), jstTime.getDate());
+}
+
+/**
+ * JSTでの月初日を取得
+ */
+export function getFirstDayOfMonthJST(date: Date = new Date()): Date {
+  const utcTime = date.getTime() + date.getTimezoneOffset() * 60 * 1000;
+  const jstTime = new Date(utcTime + JST_OFFSET_MS);
+  return new Date(jstTime.getFullYear(), jstTime.getMonth(), 1);
+}
+
+/**
+ * JSTでの月末日を取得
+ */
+export function getLastDayOfMonthJST(date: Date = new Date()): Date {
+  const utcTime = date.getTime() + date.getTimezoneOffset() * 60 * 1000;
+  const jstTime = new Date(utcTime + JST_OFFSET_MS);
+  return new Date(jstTime.getFullYear(), jstTime.getMonth() + 1, 0);
+}
+
+/**
+ * 日付を YYYY/MM/DD 形式にフォーマット
+ */
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}/${month}/${day}`;
+}
+
+/**
+ * 日付を YYYY-MM-DD 形式にフォーマット（API用）
+ */
+export function formatDateForApi(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 時刻を HH:MM 形式にフォーマット
+ */
+export function formatTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * 日付を YYYY年M月D日 形式にフォーマット
+ */
+export function formatDateJapanese(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}年${month}月${day}日`;
+}
+
+/**
+ * 日時を YYYY/MM/DD HH:MM 形式にフォーマット
+ */
+export function formatDateTime(date: Date): string {
+  return `${formatDate(date)} ${formatTime(date)}`;
+}
+
+/**
+ * 文字列をDateオブジェクトにパース
+ * @param dateString YYYY-MM-DD 形式の文字列
+ */
+export function parseDate(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/**
+ * 2つの日付が同じ日かどうかを判定
+ */
+export function isSameDate(date1: Date, date2: Date): boolean {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}
+
+/**
+ * 指定された日付が今日かどうかを判定
+ */
+export function isToday(date: Date): boolean {
+  return isSameDate(date, getTodayJST());
+}
+
+/**
+ * 日付の相対表示（○日前、○時間前など）
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 7) {
+    return formatDate(date);
+  } else if (diffDays >= 1) {
+    return `${diffDays}日前`;
+  } else if (diffHours >= 1) {
+    return `${diffHours}時間前`;
+  } else if (diffMinutes >= 1) {
+    return `${diffMinutes}分前`;
+  } else {
+    return 'たった今';
+  }
+}
+
+/**
+ * 曜日を取得
+ */
+export function getDayOfWeek(date: Date): string {
+  const days = ['日', '月', '火', '水', '木', '金', '土'];
+  return days[date.getDay()];
+}
+
+/**
+ * 日付に曜日を付加してフォーマット
+ */
+export function formatDateWithDayOfWeek(date: Date): string {
+  return `${formatDate(date)}（${getDayOfWeek(date)}）`;
+}

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,201 @@
+/**
+ * エラーハンドリング関数
+ */
+
+import { ZodError } from 'zod';
+
+/**
+ * アプリケーションエラーの基底クラス
+ */
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number = 500,
+    public code: string = 'INTERNAL_ERROR'
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+/**
+ * 認証エラー
+ */
+export class AuthenticationError extends AppError {
+  constructor(message: string = '認証が必要です') {
+    super(message, 401, 'AUTHENTICATION_REQUIRED');
+    this.name = 'AuthenticationError';
+  }
+}
+
+/**
+ * 認可エラー
+ */
+export class AuthorizationError extends AppError {
+  constructor(message: string = 'この操作を行う権限がありません') {
+    super(message, 403, 'FORBIDDEN');
+    this.name = 'AuthorizationError';
+  }
+}
+
+/**
+ * リソース未検出エラー
+ */
+export class NotFoundError extends AppError {
+  constructor(resource: string = 'リソース') {
+    super(`${resource}が見つかりません`, 404, 'NOT_FOUND');
+    this.name = 'NotFoundError';
+  }
+}
+
+/**
+ * バリデーションエラー
+ */
+export class ValidationError extends AppError {
+  public errors: Record<string, string[]>;
+
+  constructor(
+    message: string = '入力内容に誤りがあります',
+    errors: Record<string, string[]> = {}
+  ) {
+    super(message, 400, 'VALIDATION_ERROR');
+    this.name = 'ValidationError';
+    this.errors = errors;
+  }
+}
+
+/**
+ * 重複エラー
+ */
+export class DuplicateError extends AppError {
+  constructor(message: string = '既に登録されています') {
+    super(message, 409, 'DUPLICATE');
+    this.name = 'DuplicateError';
+  }
+}
+
+/**
+ * Zodエラーをバリデーションエラーに変換
+ */
+export function fromZodError(zodError: ZodError): ValidationError {
+  const errors: Record<string, string[]> = {};
+
+  for (const issue of zodError.errors) {
+    const path = issue.path.join('.');
+    if (!errors[path]) {
+      errors[path] = [];
+    }
+    errors[path].push(issue.message);
+  }
+
+  return new ValidationError('入力内容に誤りがあります', errors);
+}
+
+/**
+ * エラーメッセージを取得
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof AppError) {
+    return error.message;
+  }
+  if (error instanceof ZodError) {
+    const firstError = error.errors[0];
+    return firstError?.message ?? '入力内容に誤りがあります';
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return '予期しないエラーが発生しました';
+}
+
+/**
+ * エラーのHTTPステータスコードを取得
+ */
+export function getErrorStatusCode(error: unknown): number {
+  if (error instanceof AppError) {
+    return error.statusCode;
+  }
+  if (error instanceof ZodError) {
+    return 400;
+  }
+  return 500;
+}
+
+/**
+ * エラーコードを取得
+ */
+export function getErrorCode(error: unknown): string {
+  if (error instanceof AppError) {
+    return error.code;
+  }
+  if (error instanceof ZodError) {
+    return 'VALIDATION_ERROR';
+  }
+  return 'INTERNAL_ERROR';
+}
+
+/**
+ * エラーをログ用にフォーマット
+ */
+export function formatErrorForLog(error: unknown): Record<string, unknown> {
+  if (error instanceof AppError) {
+    return {
+      name: error.name,
+      message: error.message,
+      code: error.code,
+      statusCode: error.statusCode,
+      stack: error.stack,
+    };
+  }
+  if (error instanceof ZodError) {
+    return {
+      name: 'ZodError',
+      message: 'Validation failed',
+      errors: error.errors,
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+  return {
+    name: 'UnknownError',
+    message: String(error),
+  };
+}
+
+/**
+ * エラーが再試行可能かどうかを判定
+ */
+export function isRetryableError(error: unknown): boolean {
+  if (error instanceof AppError) {
+    // 5xxエラーは再試行可能
+    return error.statusCode >= 500;
+  }
+  return false;
+}
+
+/**
+ * エラーをユーザー向けメッセージに変換
+ */
+export function toUserFriendlyMessage(error: unknown): string {
+  if (error instanceof AuthenticationError) {
+    return 'ログインが必要です。ログインページに移動してください。';
+  }
+  if (error instanceof AuthorizationError) {
+    return 'この操作を行う権限がありません。管理者にお問い合わせください。';
+  }
+  if (error instanceof NotFoundError) {
+    return error.message;
+  }
+  if (error instanceof ValidationError) {
+    return error.message;
+  }
+  if (error instanceof DuplicateError) {
+    return error.message;
+  }
+  return 'エラーが発生しました。しばらくしてから再度お試しください。';
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,95 @@
+/**
+ * ユーティリティ関数のエクスポート
+ */
+
+// 日付ユーティリティ
+export {
+  getTodayJST,
+  getFirstDayOfMonthJST,
+  getLastDayOfMonthJST,
+  formatDate,
+  formatDateForApi,
+  formatTime,
+  formatDateJapanese,
+  formatDateTime,
+  parseDate,
+  isSameDate,
+  isToday,
+  formatRelativeTime,
+  getDayOfWeek,
+  formatDateWithDayOfWeek,
+} from './date';
+
+// ステータスヘルパー
+export {
+  getStatusColor,
+  getStatusBadgeClass,
+  getStatusIcon,
+  isStatusEditable,
+  isStatusSubmittable,
+  isStatusApprovable,
+  getStatusDescription,
+  getNextAvailableStatuses,
+  isValidStatus,
+  toReportStatus,
+} from './status';
+
+// 権限チェック
+export {
+  isManager,
+  isSalesStaff,
+  hasRole,
+  hasAnyRole,
+  isOwnReport,
+  canViewReport,
+  canEditReport,
+  canDeleteReport,
+  canApproveReport,
+  canViewSalesMaster,
+  canEditSalesMaster,
+  canEditCustomerMaster,
+  canPostComment,
+  canDeleteComment,
+  isValidRole,
+} from './permissions';
+
+// エラーハンドリング
+export {
+  AppError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ValidationError,
+  DuplicateError,
+  fromZodError,
+  getErrorMessage,
+  getErrorStatusCode,
+  getErrorCode,
+  formatErrorForLog,
+  isRetryableError,
+  toUserFriendlyMessage,
+} from './error';
+
+// API応答ヘルパー
+export type {
+  ApiSuccessResponse,
+  ApiErrorResponse,
+  ApiListResponse,
+  PaginationMeta,
+} from './api';
+export {
+  createSuccessResponse,
+  createListResponse,
+  createCreatedResponse,
+  createDeletedResponse,
+  createErrorResponse,
+  createUnauthorizedResponse,
+  createForbiddenResponse,
+  createNotFoundResponse,
+  createValidationErrorResponse,
+  calculatePagination,
+  parseRequestBody,
+  getIdFromParams,
+  getQueryParams,
+  getPaginationParams,
+} from './api';

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -1,0 +1,211 @@
+/**
+ * 権限チェック関数
+ */
+
+import { ROLES, type Role } from '../constants';
+import type { SessionUser } from '../auth';
+
+/**
+ * ユーザーが上長かどうかを判定
+ */
+export function isManager(user: SessionUser | null | undefined): boolean {
+  return user?.role === ROLES.MANAGER;
+}
+
+/**
+ * ユーザーが一般営業かどうかを判定
+ */
+export function isSalesStaff(user: SessionUser | null | undefined): boolean {
+  return user?.role === ROLES.SALES;
+}
+
+/**
+ * 指定されたロールを持っているかを判定
+ */
+export function hasRole(
+  user: SessionUser | null | undefined,
+  role: Role
+): boolean {
+  return user?.role === role;
+}
+
+/**
+ * 指定されたロールのいずれかを持っているかを判定
+ */
+export function hasAnyRole(
+  user: SessionUser | null | undefined,
+  roles: Role[]
+): boolean {
+  return user?.role != null && roles.includes(user.role as Role);
+}
+
+/**
+ * 自分の日報かどうかを判定
+ */
+export function isOwnReport(
+  user: SessionUser | null | undefined,
+  reportSalesId: number
+): boolean {
+  return user?.salesId === reportSalesId;
+}
+
+/**
+ * 日報を閲覧できるかどうかを判定
+ * - 自分の日報は閲覧可能
+ * - 上長は配下メンバーの日報を閲覧可能
+ */
+export function canViewReport(
+  user: SessionUser | null | undefined,
+  reportSalesId: number,
+  isSubordinate: boolean = false
+): boolean {
+  if (!user) return false;
+
+  // 自分の日報は閲覧可能
+  if (isOwnReport(user, reportSalesId)) {
+    return true;
+  }
+
+  // 上長は配下メンバーの日報を閲覧可能
+  if (isManager(user) && isSubordinate) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * 日報を編集できるかどうかを判定
+ * - 自分の日報のみ編集可能
+ * - 下書きまたは差し戻し状態のみ編集可能
+ */
+export function canEditReport(
+  user: SessionUser | null | undefined,
+  reportSalesId: number,
+  status: string
+): boolean {
+  if (!user) return false;
+
+  // 自分の日報のみ編集可能
+  if (!isOwnReport(user, reportSalesId)) {
+    return false;
+  }
+
+  // 下書きまたは差し戻し状態のみ編集可能
+  const editableStatuses = ['下書き', '差し戻し'];
+  return editableStatuses.includes(status);
+}
+
+/**
+ * 日報を削除できるかどうかを判定
+ * - 自分の下書き日報のみ削除可能
+ */
+export function canDeleteReport(
+  user: SessionUser | null | undefined,
+  reportSalesId: number,
+  status: string
+): boolean {
+  if (!user) return false;
+
+  // 自分の日報のみ削除可能
+  if (!isOwnReport(user, reportSalesId)) {
+    return false;
+  }
+
+  // 下書き状態のみ削除可能
+  return status === '下書き';
+}
+
+/**
+ * 日報を承認/差し戻しできるかどうかを判定
+ * - 上長のみ可能
+ * - 配下メンバーの日報のみ可能
+ * - 提出済み状態のみ可能
+ */
+export function canApproveReport(
+  user: SessionUser | null | undefined,
+  reportSalesId: number,
+  status: string,
+  isSubordinate: boolean = false
+): boolean {
+  if (!user) return false;
+
+  // 上長のみ可能
+  if (!isManager(user)) {
+    return false;
+  }
+
+  // 自分の日報は承認不可
+  if (isOwnReport(user, reportSalesId)) {
+    return false;
+  }
+
+  // 配下メンバーの日報のみ可能
+  if (!isSubordinate) {
+    return false;
+  }
+
+  // 提出済み状態のみ可能
+  return status === '提出済み';
+}
+
+/**
+ * 営業マスタを閲覧できるかどうかを判定
+ * - 上長のみ可能
+ */
+export function canViewSalesMaster(
+  user: SessionUser | null | undefined
+): boolean {
+  return isManager(user);
+}
+
+/**
+ * 営業マスタを編集できるかどうかを判定
+ * - 上長のみ可能
+ */
+export function canEditSalesMaster(
+  user: SessionUser | null | undefined
+): boolean {
+  return isManager(user);
+}
+
+/**
+ * 顧客マスタを編集できるかどうかを判定
+ * - 全員可能
+ */
+export function canEditCustomerMaster(
+  user: SessionUser | null | undefined
+): boolean {
+  return user != null;
+}
+
+/**
+ * コメントを投稿できるかどうかを判定
+ * - 日報を閲覧できるユーザーは投稿可能
+ */
+export function canPostComment(
+  user: SessionUser | null | undefined,
+  reportSalesId: number,
+  isSubordinate: boolean = false
+): boolean {
+  return canViewReport(user, reportSalesId, isSubordinate);
+}
+
+/**
+ * コメントを削除できるかどうかを判定
+ * - 自分のコメントのみ削除可能
+ */
+export function canDeleteComment(
+  user: SessionUser | null | undefined,
+  commentSalesId: number
+): boolean {
+  if (!user) return false;
+  return user.salesId === commentSalesId;
+}
+
+/**
+ * ロール値が有効かどうかを判定
+ */
+export function isValidRole(role: string): role is Role {
+  return Object.values(ROLES).includes(role as Role);
+}

--- a/src/lib/utils/status.ts
+++ b/src/lib/utils/status.ts
@@ -1,0 +1,145 @@
+/**
+ * ステータス表示ヘルパー関数
+ */
+
+import { REPORT_STATUSES, type ReportStatus } from '../constants';
+
+/**
+ * ステータスの表示色を取得
+ */
+export function getStatusColor(
+  status: ReportStatus
+): 'default' | 'secondary' | 'destructive' | 'success' {
+  switch (status) {
+    case REPORT_STATUSES.DRAFT:
+      return 'secondary';
+    case REPORT_STATUSES.SUBMITTED:
+      return 'default';
+    case REPORT_STATUSES.APPROVED:
+      return 'success';
+    case REPORT_STATUSES.REJECTED:
+      return 'destructive';
+    default:
+      return 'default';
+  }
+}
+
+/**
+ * ステータスのバッジ用CSSクラスを取得
+ */
+export function getStatusBadgeClass(status: ReportStatus): string {
+  switch (status) {
+    case REPORT_STATUSES.DRAFT:
+      return 'bg-gray-100 text-gray-800 border-gray-200';
+    case REPORT_STATUSES.SUBMITTED:
+      return 'bg-blue-100 text-blue-800 border-blue-200';
+    case REPORT_STATUSES.APPROVED:
+      return 'bg-green-100 text-green-800 border-green-200';
+    case REPORT_STATUSES.REJECTED:
+      return 'bg-red-100 text-red-800 border-red-200';
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200';
+  }
+}
+
+/**
+ * ステータスのアイコン名を取得
+ */
+export function getStatusIcon(status: ReportStatus): string {
+  switch (status) {
+    case REPORT_STATUSES.DRAFT:
+      return 'file-edit';
+    case REPORT_STATUSES.SUBMITTED:
+      return 'send';
+    case REPORT_STATUSES.APPROVED:
+      return 'check-circle';
+    case REPORT_STATUSES.REJECTED:
+      return 'x-circle';
+    default:
+      return 'file';
+  }
+}
+
+/**
+ * ステータスが編集可能かどうかを判定
+ */
+export function isStatusEditable(status: ReportStatus): boolean {
+  return (
+    status === REPORT_STATUSES.DRAFT || status === REPORT_STATUSES.REJECTED
+  );
+}
+
+/**
+ * ステータスが提出可能かどうかを判定
+ */
+export function isStatusSubmittable(status: ReportStatus): boolean {
+  return (
+    status === REPORT_STATUSES.DRAFT || status === REPORT_STATUSES.REJECTED
+  );
+}
+
+/**
+ * ステータスが承認/差し戻し可能かどうかを判定
+ */
+export function isStatusApprovable(status: ReportStatus): boolean {
+  return status === REPORT_STATUSES.SUBMITTED;
+}
+
+/**
+ * ステータスの説明テキストを取得
+ */
+export function getStatusDescription(status: ReportStatus): string {
+  switch (status) {
+    case REPORT_STATUSES.DRAFT:
+      return '下書き状態です。提出するまで上長には表示されません。';
+    case REPORT_STATUSES.SUBMITTED:
+      return '上長の承認待ちです。';
+    case REPORT_STATUSES.APPROVED:
+      return '承認済みです。';
+    case REPORT_STATUSES.REJECTED:
+      return '差し戻されました。内容を修正して再提出してください。';
+    default:
+      return '';
+  }
+}
+
+/**
+ * 次に遷移可能なステータス一覧を取得
+ */
+export function getNextAvailableStatuses(
+  currentStatus: ReportStatus,
+  isManager: boolean
+): ReportStatus[] {
+  switch (currentStatus) {
+    case REPORT_STATUSES.DRAFT:
+      return [REPORT_STATUSES.SUBMITTED];
+    case REPORT_STATUSES.SUBMITTED:
+      if (isManager) {
+        return [REPORT_STATUSES.APPROVED, REPORT_STATUSES.REJECTED];
+      }
+      return [];
+    case REPORT_STATUSES.REJECTED:
+      return [REPORT_STATUSES.SUBMITTED];
+    case REPORT_STATUSES.APPROVED:
+      return [];
+    default:
+      return [];
+  }
+}
+
+/**
+ * ステータス値が有効かどうかを判定
+ */
+export function isValidStatus(status: string): status is ReportStatus {
+  return Object.values(REPORT_STATUSES).includes(status as ReportStatus);
+}
+
+/**
+ * ステータスをReportStatus型に変換（無効な場合はnullを返す）
+ */
+export function toReportStatus(status: string): ReportStatus | null {
+  if (isValidStatus(status)) {
+    return status;
+  }
+  return null;
+}

--- a/tests/unit/utils/api.test.ts
+++ b/tests/unit/utils/api.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  createSuccessResponse,
+  createListResponse,
+  createCreatedResponse,
+  createDeletedResponse,
+  createErrorResponse,
+  createUnauthorizedResponse,
+  createForbiddenResponse,
+  createNotFoundResponse,
+  createValidationErrorResponse,
+  calculatePagination,
+  getIdFromParams,
+  getQueryParams,
+  getPaginationParams,
+} from '@/lib/utils/api';
+import { AppError } from '@/lib/utils/error';
+
+// NextResponse.jsonをモック
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body, options) => ({
+      body,
+      status: options?.status ?? 200,
+    })),
+  },
+}));
+
+describe('API応答ヘルパー関数', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createSuccessResponse', () => {
+    it('成功レスポンスを作成できる', () => {
+      const data = { id: 1, name: 'Test' };
+      createSuccessResponse(data);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: true,
+          data,
+          message: undefined,
+        },
+        { status: 200 }
+      );
+    });
+
+    it('メッセージ付きの成功レスポンスを作成できる', () => {
+      const data = { id: 1 };
+      createSuccessResponse(data, '更新しました');
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: true,
+          data,
+          message: '更新しました',
+        },
+        { status: 200 }
+      );
+    });
+
+    it('カスタムステータスコードを指定できる', () => {
+      createSuccessResponse({}, undefined, 201);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(expect.anything(), {
+        status: 201,
+      });
+    });
+  });
+
+  describe('createListResponse', () => {
+    it('リストレスポンスを作成できる', () => {
+      const data = [{ id: 1 }, { id: 2 }];
+      const pagination = { page: 1, perPage: 20, total: 100, totalPages: 5 };
+      createListResponse(data, pagination);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: true,
+          data,
+          pagination,
+        },
+        { status: 200 }
+      );
+    });
+  });
+
+  describe('createCreatedResponse', () => {
+    it('201ステータスのレスポンスを作成できる', () => {
+      const data = { id: 1 };
+      createCreatedResponse(data);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: true,
+          data,
+          message: '作成しました',
+        },
+        { status: 201 }
+      );
+    });
+  });
+
+  describe('createDeletedResponse', () => {
+    it('削除成功レスポンスを作成できる', () => {
+      createDeletedResponse();
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: true,
+          data: null,
+          message: '削除しました',
+        },
+        { status: 200 }
+      );
+    });
+  });
+
+  describe('createErrorResponse', () => {
+    it('AppErrorからエラーレスポンスを作成できる', () => {
+      const error = new AppError('テストエラー', 400, 'TEST_ERROR');
+      createErrorResponse(error);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: false,
+          error: {
+            code: 'TEST_ERROR',
+            message: 'テストエラー',
+          },
+        },
+        { status: 400 }
+      );
+    });
+
+    it('ZodErrorからエラーレスポンスを作成できる', () => {
+      const schema = z.object({
+        email: z.string().email('無効なメールアドレス'),
+      });
+
+      try {
+        schema.parse({ email: 'invalid' });
+      } catch (e) {
+        createErrorResponse(e);
+
+        expect(NextResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: expect.objectContaining({
+              code: 'VALIDATION_ERROR',
+              details: expect.any(Object),
+            }),
+          }),
+          { status: 400 }
+        );
+      }
+    });
+  });
+
+  describe('createUnauthorizedResponse', () => {
+    it('401レスポンスを作成できる', () => {
+      createUnauthorizedResponse();
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: false,
+          error: {
+            code: 'AUTHENTICATION_REQUIRED',
+            message: '認証が必要です',
+          },
+        },
+        { status: 401 }
+      );
+    });
+  });
+
+  describe('createForbiddenResponse', () => {
+    it('403レスポンスを作成できる', () => {
+      createForbiddenResponse();
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: false,
+          error: {
+            code: 'FORBIDDEN',
+            message: 'この操作を行う権限がありません',
+          },
+        },
+        { status: 403 }
+      );
+    });
+  });
+
+  describe('createNotFoundResponse', () => {
+    it('404レスポンスを作成できる', () => {
+      createNotFoundResponse('日報');
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: false,
+          error: {
+            code: 'NOT_FOUND',
+            message: '日報が見つかりません',
+          },
+        },
+        { status: 404 }
+      );
+    });
+  });
+
+  describe('createValidationErrorResponse', () => {
+    it('バリデーションエラーレスポンスを作成できる', () => {
+      const details = { email: ['メールアドレスを入力してください'] };
+      createValidationErrorResponse('入力エラー', details);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: '入力エラー',
+            details,
+          },
+        },
+        { status: 400 }
+      );
+    });
+  });
+
+  describe('calculatePagination', () => {
+    it('ページネーション情報を計算できる', () => {
+      const result = calculatePagination(100, 2, 20);
+      expect(result).toEqual({
+        page: 2,
+        perPage: 20,
+        total: 100,
+        totalPages: 5,
+      });
+    });
+
+    it('端数がある場合、切り上げで総ページ数を計算する', () => {
+      const result = calculatePagination(101, 1, 20);
+      expect(result.totalPages).toBe(6);
+    });
+  });
+
+  describe('getIdFromParams', () => {
+    it('文字列IDを数値に変換できる', () => {
+      expect(getIdFromParams({ id: '123' })).toBe(123);
+    });
+
+    it('IDがない場合エラーをスローする', () => {
+      expect(() => getIdFromParams({})).toThrow('IDが指定されていません');
+    });
+
+    it('無効なIDの場合エラーをスローする', () => {
+      expect(() => getIdFromParams({ id: 'abc' })).toThrow('無効なIDです');
+      expect(() => getIdFromParams({ id: '0' })).toThrow('無効なIDです');
+      expect(() => getIdFromParams({ id: '-1' })).toThrow('無効なIDです');
+    });
+  });
+
+  describe('getQueryParams', () => {
+    it('URLからクエリパラメータを取得できる', () => {
+      const request = new Request('http://localhost/api?page=2&status=draft');
+      const params = getQueryParams(request);
+      expect(params.page).toBe('2');
+      expect(params.status).toBe('draft');
+    });
+  });
+
+  describe('getPaginationParams', () => {
+    it('デフォルト値を返す', () => {
+      const request = new Request('http://localhost/api');
+      const { page, perPage, skip } = getPaginationParams(request);
+      expect(page).toBe(1);
+      expect(perPage).toBe(20);
+      expect(skip).toBe(0);
+    });
+
+    it('指定された値を返す', () => {
+      const request = new Request('http://localhost/api?page=3&perPage=10');
+      const { page, perPage, skip } = getPaginationParams(request);
+      expect(page).toBe(3);
+      expect(perPage).toBe(10);
+      expect(skip).toBe(20);
+    });
+
+    it('perPageは最大100に制限される', () => {
+      const request = new Request('http://localhost/api?perPage=200');
+      const { perPage } = getPaginationParams(request);
+      expect(perPage).toBe(100);
+    });
+
+    it('pageは最小1に制限される', () => {
+      const request = new Request('http://localhost/api?page=0');
+      const { page } = getPaginationParams(request);
+      expect(page).toBe(1);
+    });
+  });
+});

--- a/tests/unit/utils/date.test.ts
+++ b/tests/unit/utils/date.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getTodayJST,
+  getFirstDayOfMonthJST,
+  getLastDayOfMonthJST,
+  formatDate,
+  formatDateForApi,
+  formatTime,
+  formatDateJapanese,
+  formatDateTime,
+  parseDate,
+  isSameDate,
+  formatRelativeTime,
+  getDayOfWeek,
+  formatDateWithDayOfWeek,
+} from '@/lib/utils/date';
+
+describe('日付ユーティリティ関数', () => {
+  describe('formatDate', () => {
+    it('日付をYYYY/MM/DD形式にフォーマットできる', () => {
+      const date = new Date(2024, 0, 15); // 2024-01-15
+      expect(formatDate(date)).toBe('2024/01/15');
+    });
+
+    it('月と日が1桁の場合、ゼロ埋めされる', () => {
+      const date = new Date(2024, 0, 5); // 2024-01-05
+      expect(formatDate(date)).toBe('2024/01/05');
+    });
+  });
+
+  describe('formatDateForApi', () => {
+    it('日付をYYYY-MM-DD形式にフォーマットできる', () => {
+      const date = new Date(2024, 0, 15);
+      expect(formatDateForApi(date)).toBe('2024-01-15');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('時刻をHH:MM形式にフォーマットできる', () => {
+      const date = new Date(2024, 0, 15, 14, 30);
+      expect(formatTime(date)).toBe('14:30');
+    });
+
+    it('時と分が1桁の場合、ゼロ埋めされる', () => {
+      const date = new Date(2024, 0, 15, 9, 5);
+      expect(formatTime(date)).toBe('09:05');
+    });
+  });
+
+  describe('formatDateJapanese', () => {
+    it('日付をYYYY年M月D日形式にフォーマットできる', () => {
+      const date = new Date(2024, 0, 15);
+      expect(formatDateJapanese(date)).toBe('2024年1月15日');
+    });
+  });
+
+  describe('formatDateTime', () => {
+    it('日時をYYYY/MM/DD HH:MM形式にフォーマットできる', () => {
+      const date = new Date(2024, 0, 15, 14, 30);
+      expect(formatDateTime(date)).toBe('2024/01/15 14:30');
+    });
+  });
+
+  describe('parseDate', () => {
+    it('YYYY-MM-DD形式の文字列をDateオブジェクトにパースできる', () => {
+      const result = parseDate('2024-01-15');
+      expect(result.getFullYear()).toBe(2024);
+      expect(result.getMonth()).toBe(0); // 0-indexed
+      expect(result.getDate()).toBe(15);
+    });
+  });
+
+  describe('isSameDate', () => {
+    it('同じ日付の場合trueを返す', () => {
+      const date1 = new Date(2024, 0, 15, 10, 0);
+      const date2 = new Date(2024, 0, 15, 14, 30);
+      expect(isSameDate(date1, date2)).toBe(true);
+    });
+
+    it('異なる日付の場合falseを返す', () => {
+      const date1 = new Date(2024, 0, 15);
+      const date2 = new Date(2024, 0, 16);
+      expect(isSameDate(date1, date2)).toBe(false);
+    });
+  });
+
+  describe('getDayOfWeek', () => {
+    it('日曜日の場合「日」を返す', () => {
+      const date = new Date(2024, 0, 14); // Sunday
+      expect(getDayOfWeek(date)).toBe('日');
+    });
+
+    it('月曜日の場合「月」を返す', () => {
+      const date = new Date(2024, 0, 15); // Monday
+      expect(getDayOfWeek(date)).toBe('月');
+    });
+  });
+
+  describe('formatDateWithDayOfWeek', () => {
+    it('日付に曜日を付加してフォーマットできる', () => {
+      const date = new Date(2024, 0, 15); // Monday
+      expect(formatDateWithDayOfWeek(date)).toBe('2024/01/15（月）');
+    });
+  });
+
+  describe('getTodayJST', () => {
+    it('Dateオブジェクトを返す', () => {
+      const today = getTodayJST();
+      expect(today).toBeInstanceOf(Date);
+    });
+
+    it('時刻が00:00:00になっている', () => {
+      const today = getTodayJST();
+      expect(today.getHours()).toBe(0);
+      expect(today.getMinutes()).toBe(0);
+      expect(today.getSeconds()).toBe(0);
+    });
+  });
+
+  describe('getFirstDayOfMonthJST', () => {
+    it('月初日を返す', () => {
+      const date = new Date(2024, 5, 15); // June 15, 2024
+      const firstDay = getFirstDayOfMonthJST(date);
+      expect(firstDay.getDate()).toBe(1);
+    });
+  });
+
+  describe('getLastDayOfMonthJST', () => {
+    it('月末日を返す', () => {
+      const date = new Date(2024, 0, 15); // January 15, 2024
+      const lastDay = getLastDayOfMonthJST(date);
+      expect(lastDay.getDate()).toBe(31);
+    });
+
+    it('2月の月末日を正しく返す（閏年）', () => {
+      const date = new Date(2024, 1, 15); // February 15, 2024 (leap year)
+      const lastDay = getLastDayOfMonthJST(date);
+      expect(lastDay.getDate()).toBe(29);
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('1分未満の場合「たった今」を返す', () => {
+      const now = new Date(2024, 0, 15, 12, 0, 0);
+      vi.setSystemTime(now);
+      const date = new Date(2024, 0, 15, 11, 59, 50);
+      expect(formatRelativeTime(date)).toBe('たった今');
+    });
+
+    it('1時間未満の場合「○分前」を返す', () => {
+      const now = new Date(2024, 0, 15, 12, 0, 0);
+      vi.setSystemTime(now);
+      const date = new Date(2024, 0, 15, 11, 30, 0);
+      expect(formatRelativeTime(date)).toBe('30分前');
+    });
+
+    it('1日未満の場合「○時間前」を返す', () => {
+      const now = new Date(2024, 0, 15, 12, 0, 0);
+      vi.setSystemTime(now);
+      const date = new Date(2024, 0, 15, 9, 0, 0);
+      expect(formatRelativeTime(date)).toBe('3時間前');
+    });
+
+    it('7日以内の場合「○日前」を返す', () => {
+      const now = new Date(2024, 0, 15, 12, 0, 0);
+      vi.setSystemTime(now);
+      const date = new Date(2024, 0, 12, 12, 0, 0);
+      expect(formatRelativeTime(date)).toBe('3日前');
+    });
+
+    it('7日より前の場合、日付をフォーマットして返す', () => {
+      const now = new Date(2024, 0, 15, 12, 0, 0);
+      vi.setSystemTime(now);
+      const date = new Date(2024, 0, 1, 12, 0, 0);
+      expect(formatRelativeTime(date)).toBe('2024/01/01');
+    });
+  });
+});

--- a/tests/unit/utils/error.test.ts
+++ b/tests/unit/utils/error.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  AppError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ValidationError,
+  DuplicateError,
+  fromZodError,
+  getErrorMessage,
+  getErrorStatusCode,
+  getErrorCode,
+  formatErrorForLog,
+  isRetryableError,
+  toUserFriendlyMessage,
+} from '@/lib/utils/error';
+
+describe('エラーハンドリング関数', () => {
+  describe('AppError', () => {
+    it('カスタムメッセージとステータスコードを持つ', () => {
+      const error = new AppError('カスタムエラー', 400, 'CUSTOM_ERROR');
+      expect(error.message).toBe('カスタムエラー');
+      expect(error.statusCode).toBe(400);
+      expect(error.code).toBe('CUSTOM_ERROR');
+    });
+
+    it('デフォルト値を持つ', () => {
+      const error = new AppError('エラー');
+      expect(error.statusCode).toBe(500);
+      expect(error.code).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  describe('AuthenticationError', () => {
+    it('401ステータスコードを持つ', () => {
+      const error = new AuthenticationError();
+      expect(error.statusCode).toBe(401);
+      expect(error.code).toBe('AUTHENTICATION_REQUIRED');
+    });
+
+    it('カスタムメッセージを指定できる', () => {
+      const error = new AuthenticationError('セッションが切れました');
+      expect(error.message).toBe('セッションが切れました');
+    });
+  });
+
+  describe('AuthorizationError', () => {
+    it('403ステータスコードを持つ', () => {
+      const error = new AuthorizationError();
+      expect(error.statusCode).toBe(403);
+      expect(error.code).toBe('FORBIDDEN');
+    });
+  });
+
+  describe('NotFoundError', () => {
+    it('404ステータスコードを持つ', () => {
+      const error = new NotFoundError('日報');
+      expect(error.statusCode).toBe(404);
+      expect(error.message).toBe('日報が見つかりません');
+    });
+  });
+
+  describe('ValidationError', () => {
+    it('400ステータスコードを持つ', () => {
+      const error = new ValidationError();
+      expect(error.statusCode).toBe(400);
+      expect(error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('エラー詳細を持てる', () => {
+      const errors = {
+        email: ['メールアドレスを入力してください'],
+        password: ['パスワードを入力してください'],
+      };
+      const error = new ValidationError('バリデーションエラー', errors);
+      expect(error.errors).toEqual(errors);
+    });
+  });
+
+  describe('DuplicateError', () => {
+    it('409ステータスコードを持つ', () => {
+      const error = new DuplicateError();
+      expect(error.statusCode).toBe(409);
+      expect(error.code).toBe('DUPLICATE');
+    });
+  });
+
+  describe('fromZodError', () => {
+    it('ZodエラーをValidationErrorに変換できる', () => {
+      const schema = z.object({
+        email: z.string().email('メールアドレスが無効です'),
+        password: z.string().min(8, '8文字以上必要です'),
+      });
+
+      try {
+        schema.parse({ email: 'invalid', password: '123' });
+      } catch (e) {
+        if (e instanceof z.ZodError) {
+          const validationError = fromZodError(e);
+          expect(validationError).toBeInstanceOf(ValidationError);
+          expect(validationError.errors.email).toContain(
+            'メールアドレスが無効です'
+          );
+          expect(validationError.errors.password).toContain(
+            '8文字以上必要です'
+          );
+        }
+      }
+    });
+  });
+
+  describe('getErrorMessage', () => {
+    it('AppErrorからメッセージを取得できる', () => {
+      const error = new AppError('テストエラー');
+      expect(getErrorMessage(error)).toBe('テストエラー');
+    });
+
+    it('ZodErrorから最初のメッセージを取得できる', () => {
+      const schema = z.string().min(1, '入力必須です');
+      try {
+        schema.parse('');
+      } catch (e) {
+        if (e instanceof z.ZodError) {
+          expect(getErrorMessage(e)).toBe('入力必須です');
+        }
+      }
+    });
+
+    it('通常のErrorからメッセージを取得できる', () => {
+      const error = new Error('通常のエラー');
+      expect(getErrorMessage(error)).toBe('通常のエラー');
+    });
+
+    it('不明なエラーの場合デフォルトメッセージを返す', () => {
+      expect(getErrorMessage(null)).toBe('予期しないエラーが発生しました');
+    });
+  });
+
+  describe('getErrorStatusCode', () => {
+    it('AppErrorからステータスコードを取得できる', () => {
+      expect(getErrorStatusCode(new AuthenticationError())).toBe(401);
+      expect(getErrorStatusCode(new NotFoundError())).toBe(404);
+    });
+
+    it('ZodErrorの場合400を返す', () => {
+      const schema = z.string();
+      try {
+        schema.parse(123);
+      } catch (e) {
+        expect(getErrorStatusCode(e)).toBe(400);
+      }
+    });
+
+    it('不明なエラーの場合500を返す', () => {
+      expect(getErrorStatusCode(new Error())).toBe(500);
+    });
+  });
+
+  describe('getErrorCode', () => {
+    it('AppErrorからコードを取得できる', () => {
+      expect(getErrorCode(new AuthenticationError())).toBe(
+        'AUTHENTICATION_REQUIRED'
+      );
+    });
+
+    it('ZodErrorの場合VALIDATION_ERRORを返す', () => {
+      const schema = z.string();
+      try {
+        schema.parse(123);
+      } catch (e) {
+        expect(getErrorCode(e)).toBe('VALIDATION_ERROR');
+      }
+    });
+
+    it('不明なエラーの場合INTERNAL_ERRORを返す', () => {
+      expect(getErrorCode(new Error())).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  describe('formatErrorForLog', () => {
+    it('AppErrorをログ用にフォーマットできる', () => {
+      const error = new AppError('テスト', 400, 'TEST');
+      const formatted = formatErrorForLog(error);
+      expect(formatted.name).toBe('AppError');
+      expect(formatted.message).toBe('テスト');
+      expect(formatted.code).toBe('TEST');
+      expect(formatted.statusCode).toBe(400);
+    });
+
+    it('ZodErrorをログ用にフォーマットできる', () => {
+      const schema = z.string();
+      try {
+        schema.parse(123);
+      } catch (e) {
+        const formatted = formatErrorForLog(e);
+        expect(formatted.name).toBe('ZodError');
+      }
+    });
+  });
+
+  describe('isRetryableError', () => {
+    it('5xxエラーは再試行可能', () => {
+      expect(isRetryableError(new AppError('Server Error', 500))).toBe(true);
+      expect(isRetryableError(new AppError('Bad Gateway', 502))).toBe(true);
+    });
+
+    it('4xxエラーは再試行不可', () => {
+      expect(isRetryableError(new AuthenticationError())).toBe(false);
+      expect(isRetryableError(new NotFoundError())).toBe(false);
+    });
+
+    it('不明なエラーは再試行不可', () => {
+      expect(isRetryableError(new Error())).toBe(false);
+    });
+  });
+
+  describe('toUserFriendlyMessage', () => {
+    it('AuthenticationErrorの場合ユーザー向けメッセージを返す', () => {
+      const message = toUserFriendlyMessage(new AuthenticationError());
+      expect(message).toContain('ログイン');
+    });
+
+    it('AuthorizationErrorの場合ユーザー向けメッセージを返す', () => {
+      const message = toUserFriendlyMessage(new AuthorizationError());
+      expect(message).toContain('権限');
+    });
+
+    it('NotFoundErrorの場合エラーメッセージをそのまま返す', () => {
+      const message = toUserFriendlyMessage(new NotFoundError('日報'));
+      expect(message).toBe('日報が見つかりません');
+    });
+
+    it('不明なエラーの場合汎用メッセージを返す', () => {
+      const message = toUserFriendlyMessage(new Error('Unknown'));
+      expect(message).toContain('エラーが発生しました');
+    });
+  });
+});

--- a/tests/unit/utils/permissions.test.ts
+++ b/tests/unit/utils/permissions.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isManager,
+  isSalesStaff,
+  hasRole,
+  hasAnyRole,
+  isOwnReport,
+  canViewReport,
+  canEditReport,
+  canDeleteReport,
+  canApproveReport,
+  canViewSalesMaster,
+  canEditSalesMaster,
+  canEditCustomerMaster,
+  canPostComment,
+  canDeleteComment,
+  isValidRole,
+} from '@/lib/utils/permissions';
+import { ROLES } from '@/lib/constants';
+import type { SessionUser } from '@/lib/auth';
+
+describe('権限チェック関数', () => {
+  const managerUser: SessionUser = {
+    salesId: 1,
+    role: ROLES.MANAGER,
+    department: '営業部',
+    name: '上長太郎',
+    email: 'manager@example.com',
+  };
+
+  const salesUser: SessionUser = {
+    salesId: 2,
+    role: ROLES.SALES,
+    department: '営業部',
+    name: '営業花子',
+    email: 'sales@example.com',
+  };
+
+  describe('isManager', () => {
+    it('上長の場合trueを返す', () => {
+      expect(isManager(managerUser)).toBe(true);
+    });
+
+    it('一般営業の場合falseを返す', () => {
+      expect(isManager(salesUser)).toBe(false);
+    });
+
+    it('nullの場合falseを返す', () => {
+      expect(isManager(null)).toBe(false);
+    });
+
+    it('undefinedの場合falseを返す', () => {
+      expect(isManager(undefined)).toBe(false);
+    });
+  });
+
+  describe('isSalesStaff', () => {
+    it('一般営業の場合trueを返す', () => {
+      expect(isSalesStaff(salesUser)).toBe(true);
+    });
+
+    it('上長の場合falseを返す', () => {
+      expect(isSalesStaff(managerUser)).toBe(false);
+    });
+  });
+
+  describe('hasRole', () => {
+    it('指定されたロールを持っている場合trueを返す', () => {
+      expect(hasRole(managerUser, ROLES.MANAGER)).toBe(true);
+      expect(hasRole(salesUser, ROLES.SALES)).toBe(true);
+    });
+
+    it('指定されたロールを持っていない場合falseを返す', () => {
+      expect(hasRole(managerUser, ROLES.SALES)).toBe(false);
+      expect(hasRole(salesUser, ROLES.MANAGER)).toBe(false);
+    });
+  });
+
+  describe('hasAnyRole', () => {
+    it('指定されたロールのいずれかを持っている場合trueを返す', () => {
+      expect(hasAnyRole(managerUser, [ROLES.MANAGER, ROLES.SALES])).toBe(true);
+      expect(hasAnyRole(salesUser, [ROLES.MANAGER, ROLES.SALES])).toBe(true);
+    });
+
+    it('指定されたロールのいずれも持っていない場合falseを返す', () => {
+      expect(hasAnyRole(salesUser, [ROLES.MANAGER])).toBe(false);
+    });
+
+    it('nullの場合falseを返す', () => {
+      expect(hasAnyRole(null, [ROLES.MANAGER, ROLES.SALES])).toBe(false);
+    });
+  });
+
+  describe('isOwnReport', () => {
+    it('自分の日報の場合trueを返す', () => {
+      expect(isOwnReport(salesUser, 2)).toBe(true);
+    });
+
+    it('他人の日報の場合falseを返す', () => {
+      expect(isOwnReport(salesUser, 1)).toBe(false);
+    });
+
+    it('nullの場合falseを返す', () => {
+      expect(isOwnReport(null, 1)).toBe(false);
+    });
+  });
+
+  describe('canViewReport', () => {
+    it('自分の日報は閲覧可能', () => {
+      expect(canViewReport(salesUser, 2)).toBe(true);
+    });
+
+    it('上長は配下メンバーの日報を閲覧可能', () => {
+      expect(canViewReport(managerUser, 2, true)).toBe(true);
+    });
+
+    it('上長でも配下メンバーでない日報は閲覧不可', () => {
+      expect(canViewReport(managerUser, 2, false)).toBe(false);
+    });
+
+    it('一般営業は他人の日報を閲覧不可', () => {
+      expect(canViewReport(salesUser, 1, false)).toBe(false);
+    });
+  });
+
+  describe('canEditReport', () => {
+    it('自分の下書き日報は編集可能', () => {
+      expect(canEditReport(salesUser, 2, '下書き')).toBe(true);
+    });
+
+    it('自分の差し戻し日報は編集可能', () => {
+      expect(canEditReport(salesUser, 2, '差し戻し')).toBe(true);
+    });
+
+    it('自分の提出済み日報は編集不可', () => {
+      expect(canEditReport(salesUser, 2, '提出済み')).toBe(false);
+    });
+
+    it('他人の日報は編集不可', () => {
+      expect(canEditReport(salesUser, 1, '下書き')).toBe(false);
+    });
+  });
+
+  describe('canDeleteReport', () => {
+    it('自分の下書き日報は削除可能', () => {
+      expect(canDeleteReport(salesUser, 2, '下書き')).toBe(true);
+    });
+
+    it('自分の提出済み日報は削除不可', () => {
+      expect(canDeleteReport(salesUser, 2, '提出済み')).toBe(false);
+    });
+
+    it('他人の下書き日報は削除不可', () => {
+      expect(canDeleteReport(salesUser, 1, '下書き')).toBe(false);
+    });
+  });
+
+  describe('canApproveReport', () => {
+    it('上長は配下メンバーの提出済み日報を承認可能', () => {
+      expect(canApproveReport(managerUser, 2, '提出済み', true)).toBe(true);
+    });
+
+    it('上長でも自分の日報は承認不可', () => {
+      expect(canApproveReport(managerUser, 1, '提出済み', true)).toBe(false);
+    });
+
+    it('上長でも配下メンバーでない日報は承認不可', () => {
+      expect(canApproveReport(managerUser, 2, '提出済み', false)).toBe(false);
+    });
+
+    it('上長でも下書き日報は承認不可', () => {
+      expect(canApproveReport(managerUser, 2, '下書き', true)).toBe(false);
+    });
+
+    it('一般営業は日報を承認不可', () => {
+      expect(canApproveReport(salesUser, 1, '提出済み', true)).toBe(false);
+    });
+  });
+
+  describe('canViewSalesMaster', () => {
+    it('上長は営業マスタを閲覧可能', () => {
+      expect(canViewSalesMaster(managerUser)).toBe(true);
+    });
+
+    it('一般営業は営業マスタを閲覧不可', () => {
+      expect(canViewSalesMaster(salesUser)).toBe(false);
+    });
+  });
+
+  describe('canEditSalesMaster', () => {
+    it('上長は営業マスタを編集可能', () => {
+      expect(canEditSalesMaster(managerUser)).toBe(true);
+    });
+
+    it('一般営業は営業マスタを編集不可', () => {
+      expect(canEditSalesMaster(salesUser)).toBe(false);
+    });
+  });
+
+  describe('canEditCustomerMaster', () => {
+    it('ログインユーザーは顧客マスタを編集可能', () => {
+      expect(canEditCustomerMaster(salesUser)).toBe(true);
+      expect(canEditCustomerMaster(managerUser)).toBe(true);
+    });
+
+    it('未ログインユーザーは顧客マスタを編集不可', () => {
+      expect(canEditCustomerMaster(null)).toBe(false);
+    });
+  });
+
+  describe('canPostComment', () => {
+    it('日報を閲覧できるユーザーはコメント投稿可能', () => {
+      expect(canPostComment(salesUser, 2)).toBe(true);
+      expect(canPostComment(managerUser, 2, true)).toBe(true);
+    });
+  });
+
+  describe('canDeleteComment', () => {
+    it('自分のコメントは削除可能', () => {
+      expect(canDeleteComment(salesUser, 2)).toBe(true);
+    });
+
+    it('他人のコメントは削除不可', () => {
+      expect(canDeleteComment(salesUser, 1)).toBe(false);
+    });
+  });
+
+  describe('isValidRole', () => {
+    it('有効なロールの場合trueを返す', () => {
+      expect(isValidRole('上長')).toBe(true);
+      expect(isValidRole('一般営業')).toBe(true);
+    });
+
+    it('無効なロールの場合falseを返す', () => {
+      expect(isValidRole('無効')).toBe(false);
+      expect(isValidRole('')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/utils/status.test.ts
+++ b/tests/unit/utils/status.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getStatusColor,
+  getStatusBadgeClass,
+  getStatusIcon,
+  isStatusEditable,
+  isStatusSubmittable,
+  isStatusApprovable,
+  getStatusDescription,
+  getNextAvailableStatuses,
+  isValidStatus,
+  toReportStatus,
+} from '@/lib/utils/status';
+import { REPORT_STATUSES } from '@/lib/constants';
+
+describe('ステータスヘルパー関数', () => {
+  describe('getStatusColor', () => {
+    it('下書きの場合secondaryを返す', () => {
+      expect(getStatusColor(REPORT_STATUSES.DRAFT)).toBe('secondary');
+    });
+
+    it('提出済みの場合defaultを返す', () => {
+      expect(getStatusColor(REPORT_STATUSES.SUBMITTED)).toBe('default');
+    });
+
+    it('承認済みの場合successを返す', () => {
+      expect(getStatusColor(REPORT_STATUSES.APPROVED)).toBe('success');
+    });
+
+    it('差し戻しの場合destructiveを返す', () => {
+      expect(getStatusColor(REPORT_STATUSES.REJECTED)).toBe('destructive');
+    });
+  });
+
+  describe('getStatusBadgeClass', () => {
+    it('下書きの場合グレーのクラスを返す', () => {
+      const result = getStatusBadgeClass(REPORT_STATUSES.DRAFT);
+      expect(result).toContain('bg-gray-100');
+    });
+
+    it('提出済みの場合青のクラスを返す', () => {
+      const result = getStatusBadgeClass(REPORT_STATUSES.SUBMITTED);
+      expect(result).toContain('bg-blue-100');
+    });
+
+    it('承認済みの場合緑のクラスを返す', () => {
+      const result = getStatusBadgeClass(REPORT_STATUSES.APPROVED);
+      expect(result).toContain('bg-green-100');
+    });
+
+    it('差し戻しの場合赤のクラスを返す', () => {
+      const result = getStatusBadgeClass(REPORT_STATUSES.REJECTED);
+      expect(result).toContain('bg-red-100');
+    });
+  });
+
+  describe('getStatusIcon', () => {
+    it('下書きの場合file-editを返す', () => {
+      expect(getStatusIcon(REPORT_STATUSES.DRAFT)).toBe('file-edit');
+    });
+
+    it('提出済みの場合sendを返す', () => {
+      expect(getStatusIcon(REPORT_STATUSES.SUBMITTED)).toBe('send');
+    });
+
+    it('承認済みの場合check-circleを返す', () => {
+      expect(getStatusIcon(REPORT_STATUSES.APPROVED)).toBe('check-circle');
+    });
+
+    it('差し戻しの場合x-circleを返す', () => {
+      expect(getStatusIcon(REPORT_STATUSES.REJECTED)).toBe('x-circle');
+    });
+  });
+
+  describe('isStatusEditable', () => {
+    it('下書きの場合trueを返す', () => {
+      expect(isStatusEditable(REPORT_STATUSES.DRAFT)).toBe(true);
+    });
+
+    it('差し戻しの場合trueを返す', () => {
+      expect(isStatusEditable(REPORT_STATUSES.REJECTED)).toBe(true);
+    });
+
+    it('提出済みの場合falseを返す', () => {
+      expect(isStatusEditable(REPORT_STATUSES.SUBMITTED)).toBe(false);
+    });
+
+    it('承認済みの場合falseを返す', () => {
+      expect(isStatusEditable(REPORT_STATUSES.APPROVED)).toBe(false);
+    });
+  });
+
+  describe('isStatusSubmittable', () => {
+    it('下書きの場合trueを返す', () => {
+      expect(isStatusSubmittable(REPORT_STATUSES.DRAFT)).toBe(true);
+    });
+
+    it('差し戻しの場合trueを返す', () => {
+      expect(isStatusSubmittable(REPORT_STATUSES.REJECTED)).toBe(true);
+    });
+
+    it('提出済みの場合falseを返す', () => {
+      expect(isStatusSubmittable(REPORT_STATUSES.SUBMITTED)).toBe(false);
+    });
+
+    it('承認済みの場合falseを返す', () => {
+      expect(isStatusSubmittable(REPORT_STATUSES.APPROVED)).toBe(false);
+    });
+  });
+
+  describe('isStatusApprovable', () => {
+    it('提出済みの場合trueを返す', () => {
+      expect(isStatusApprovable(REPORT_STATUSES.SUBMITTED)).toBe(true);
+    });
+
+    it('下書きの場合falseを返す', () => {
+      expect(isStatusApprovable(REPORT_STATUSES.DRAFT)).toBe(false);
+    });
+
+    it('承認済みの場合falseを返す', () => {
+      expect(isStatusApprovable(REPORT_STATUSES.APPROVED)).toBe(false);
+    });
+
+    it('差し戻しの場合falseを返す', () => {
+      expect(isStatusApprovable(REPORT_STATUSES.REJECTED)).toBe(false);
+    });
+  });
+
+  describe('getStatusDescription', () => {
+    it('下書きの場合、説明文を返す', () => {
+      const description = getStatusDescription(REPORT_STATUSES.DRAFT);
+      expect(description).toContain('下書き');
+    });
+
+    it('提出済みの場合、説明文を返す', () => {
+      const description = getStatusDescription(REPORT_STATUSES.SUBMITTED);
+      expect(description).toContain('承認待ち');
+    });
+
+    it('承認済みの場合、説明文を返す', () => {
+      const description = getStatusDescription(REPORT_STATUSES.APPROVED);
+      expect(description).toContain('承認済み');
+    });
+
+    it('差し戻しの場合、説明文を返す', () => {
+      const description = getStatusDescription(REPORT_STATUSES.REJECTED);
+      expect(description).toContain('差し戻されました');
+    });
+  });
+
+  describe('getNextAvailableStatuses', () => {
+    it('下書きの場合、提出済みのみを返す', () => {
+      const statuses = getNextAvailableStatuses(REPORT_STATUSES.DRAFT, false);
+      expect(statuses).toEqual([REPORT_STATUSES.SUBMITTED]);
+    });
+
+    it('提出済みで上長の場合、承認済みと差し戻しを返す', () => {
+      const statuses = getNextAvailableStatuses(
+        REPORT_STATUSES.SUBMITTED,
+        true
+      );
+      expect(statuses).toContain(REPORT_STATUSES.APPROVED);
+      expect(statuses).toContain(REPORT_STATUSES.REJECTED);
+    });
+
+    it('提出済みで一般営業の場合、空配列を返す', () => {
+      const statuses = getNextAvailableStatuses(
+        REPORT_STATUSES.SUBMITTED,
+        false
+      );
+      expect(statuses).toEqual([]);
+    });
+
+    it('差し戻しの場合、提出済みのみを返す', () => {
+      const statuses = getNextAvailableStatuses(
+        REPORT_STATUSES.REJECTED,
+        false
+      );
+      expect(statuses).toEqual([REPORT_STATUSES.SUBMITTED]);
+    });
+
+    it('承認済みの場合、空配列を返す', () => {
+      const statuses = getNextAvailableStatuses(REPORT_STATUSES.APPROVED, true);
+      expect(statuses).toEqual([]);
+    });
+  });
+
+  describe('isValidStatus', () => {
+    it('有効なステータスの場合trueを返す', () => {
+      expect(isValidStatus('下書き')).toBe(true);
+      expect(isValidStatus('提出済み')).toBe(true);
+      expect(isValidStatus('承認済み')).toBe(true);
+      expect(isValidStatus('差し戻し')).toBe(true);
+    });
+
+    it('無効なステータスの場合falseを返す', () => {
+      expect(isValidStatus('無効')).toBe(false);
+      expect(isValidStatus('')).toBe(false);
+    });
+  });
+
+  describe('toReportStatus', () => {
+    it('有効なステータスの場合、そのステータスを返す', () => {
+      expect(toReportStatus('下書き')).toBe(REPORT_STATUSES.DRAFT);
+    });
+
+    it('無効なステータスの場合、nullを返す', () => {
+      expect(toReportStatus('無効')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 日付フォーマット関数（`src/lib/utils/date.ts`）を実装
- ステータス表示ヘルパー（`src/lib/utils/status.ts`）を実装
- 権限チェック関数（`src/lib/utils/permissions.ts`）を実装
- エラーハンドリング関数（`src/lib/utils/error.ts`）を実装
- API応答ヘルパー（`src/lib/utils/api.ts`）を実装
- 単体テスト152件を追加

## Related Issue
Closes #23

## Test plan
- [x] `npm run test -- tests/unit/utils/` で152件のテストがすべてパス
- [x] `npm run lint` でエラーなし
- [x] `npm run type-check` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)