### PR TITLE
feat: Issue #25 エラーハンドリングとエラーページの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-hook-form": "^7.71.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "zod": "^3.25.76"
       },
@@ -10046,6 +10047,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-hook-form": "^7.71.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^3.25.76"
   },

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { logError } from '@/lib/utils/logger';
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    logError(error, {
+      context: 'GlobalErrorBoundary',
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl text-destructive">
+            エラーが発生しました
+          </CardTitle>
+          <CardDescription>
+            申し訳ございません。予期しないエラーが発生しました。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-sm text-muted-foreground">
+            問題が解決しない場合は、管理者にお問い合わせください。
+          </p>
+          {error.digest && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              エラーID: {error.digest}
+            </p>
+          )}
+        </CardContent>
+        <CardFooter className="flex justify-center gap-4">
+          <Button
+            variant="outline"
+            onClick={() => (window.location.href = '/')}
+          >
+            ホームに戻る
+          </Button>
+          <Button onClick={reset}>再試行</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Toaster } from '@/components/ui/toast';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -13,7 +14,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-6xl font-bold text-muted-foreground">
+            404
+          </CardTitle>
+          <CardDescription className="text-lg">
+            ページが見つかりません
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center">
+          <p className="text-sm text-muted-foreground">
+            お探しのページは存在しないか、移動した可能性があります。
+          </p>
+        </CardContent>
+        <CardFooter className="flex justify-center gap-4">
+          <Button asChild>
+            <Link href="/">ホームに戻る</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/dashboard">ダッシュボードへ</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Toaster as SonnerToaster } from 'sonner';
+
+export function Toaster() {
+  return (
+    <SonnerToaster
+      position="top-right"
+      toastOptions={{
+        duration: 5000,
+        classNames: {
+          toast:
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton:
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton:
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+          error:
+            'group-[.toaster]:bg-destructive group-[.toaster]:text-destructive-foreground group-[.toaster]:border-destructive',
+          success:
+            'group-[.toaster]:bg-green-500 group-[.toaster]:text-white group-[.toaster]:border-green-600',
+          warning:
+            'group-[.toaster]:bg-yellow-500 group-[.toaster]:text-white group-[.toaster]:border-yellow-600',
+          info: 'group-[.toaster]:bg-blue-500 group-[.toaster]:text-white group-[.toaster]:border-blue-600',
+        },
+      }}
+    />
+  );
+}
+
+export { toast } from 'sonner';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -92,4 +92,28 @@ export {
   getIdFromParams,
   getQueryParams,
   getPaginationParams,
+  withErrorHandler,
 } from './api';
+
+// ログユーティリティ
+export type { LogLevel, LogContext } from './logger';
+export {
+  logDebug,
+  logInfo,
+  logWarn,
+  logError,
+  logApiRequest,
+  logAuth,
+  logSecurity,
+} from './logger';
+
+// トースト通知
+export {
+  showSuccessToast,
+  showErrorToast,
+  showApiErrorToast,
+  showWarningToast,
+  showInfoToast,
+  showLoadingToast,
+  fetchWithToast,
+} from './toast';

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -1,0 +1,151 @@
+/**
+ * エラーログ記録ユーティリティ
+ */
+
+import { formatErrorForLog } from './error';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogContext {
+  context?: string;
+  userId?: string;
+  method?: string;
+  url?: string;
+  digest?: string;
+  [key: string]: unknown;
+}
+
+interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  error?: Record<string, unknown>;
+  context?: LogContext;
+}
+
+/**
+ * ログエントリを作成
+ */
+function createLogEntry(
+  level: LogLevel,
+  message: string,
+  error?: unknown,
+  context?: LogContext
+): LogEntry {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+  };
+
+  if (error) {
+    entry.error = formatErrorForLog(error);
+  }
+
+  if (context) {
+    entry.context = context;
+  }
+
+  return entry;
+}
+
+/**
+ * ログを出力
+ */
+function outputLog(entry: LogEntry): void {
+  const logString = JSON.stringify(entry);
+
+  switch (entry.level) {
+    case 'debug':
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(logString);
+      }
+      break;
+    case 'info':
+      console.info(logString);
+      break;
+    case 'warn':
+      console.warn(logString);
+      break;
+    case 'error':
+      console.error(logString);
+      break;
+  }
+}
+
+/**
+ * デバッグログを出力（開発環境のみ）
+ */
+export function logDebug(message: string, context?: LogContext): void {
+  const entry = createLogEntry('debug', message, undefined, context);
+  outputLog(entry);
+}
+
+/**
+ * 情報ログを出力
+ */
+export function logInfo(message: string, context?: LogContext): void {
+  const entry = createLogEntry('info', message, undefined, context);
+  outputLog(entry);
+}
+
+/**
+ * 警告ログを出力
+ */
+export function logWarn(message: string, context?: LogContext): void {
+  const entry = createLogEntry('warn', message, undefined, context);
+  outputLog(entry);
+}
+
+/**
+ * エラーログを出力
+ */
+export function logError(error: unknown, context?: LogContext): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const entry = createLogEntry('error', message, error, context);
+  outputLog(entry);
+}
+
+/**
+ * APIリクエストのログを出力
+ */
+export function logApiRequest(
+  method: string,
+  url: string,
+  statusCode: number,
+  durationMs: number,
+  userId?: string
+): void {
+  logInfo(`API ${method} ${url} ${statusCode} ${durationMs}ms`, {
+    method,
+    url,
+    statusCode,
+    durationMs,
+    userId,
+  } as LogContext);
+}
+
+/**
+ * 認証関連のログを出力
+ */
+export function logAuth(
+  action: 'login' | 'logout' | 'session_expired' | 'unauthorized',
+  userId?: string,
+  context?: LogContext
+): void {
+  logInfo(`Auth: ${action}`, {
+    ...context,
+    action,
+    userId,
+  });
+}
+
+/**
+ * セキュリティ関連のログを出力
+ */
+export function logSecurity(
+  event: string,
+  details: Record<string, unknown>
+): void {
+  logWarn(`Security: ${event}`, details as LogContext);
+}

--- a/src/lib/utils/toast.ts
+++ b/src/lib/utils/toast.ts
@@ -1,0 +1,105 @@
+/**
+ * トースト通知ヘルパー関数
+ */
+
+import { toast } from 'sonner';
+import { getErrorMessage, toUserFriendlyMessage } from './error';
+import type { ApiErrorResponse } from './api';
+
+/**
+ * 成功トーストを表示
+ */
+export function showSuccessToast(message: string, description?: string) {
+  toast.success(message, {
+    description,
+  });
+}
+
+/**
+ * エラートーストを表示
+ */
+export function showErrorToast(
+  error: unknown,
+  fallbackMessage = 'エラーが発生しました'
+) {
+  const message = error ? toUserFriendlyMessage(error) : fallbackMessage;
+  toast.error(message);
+}
+
+/**
+ * APIエラーレスポンスからトーストを表示
+ */
+export function showApiErrorToast(response: ApiErrorResponse) {
+  const message = response.error.message || 'エラーが発生しました';
+  toast.error(message);
+}
+
+/**
+ * 警告トーストを表示
+ */
+export function showWarningToast(message: string, description?: string) {
+  toast.warning(message, {
+    description,
+  });
+}
+
+/**
+ * 情報トーストを表示
+ */
+export function showInfoToast(message: string, description?: string) {
+  toast.info(message, {
+    description,
+  });
+}
+
+/**
+ * ローディングトーストを表示
+ * 返された promise を使って状態を更新可能
+ */
+export function showLoadingToast<T>(
+  promise: Promise<T>,
+  options: {
+    loading: string;
+    success: string | ((data: T) => string);
+    error: string | ((error: unknown) => string);
+  }
+) {
+  return toast.promise(promise, {
+    loading: options.loading,
+    success: options.success,
+    error: (err) =>
+      typeof options.error === 'function'
+        ? options.error(err)
+        : getErrorMessage(err) || options.error,
+  });
+}
+
+/**
+ * fetchエラーハンドリング付きのラッパー
+ */
+export async function fetchWithToast<T>(
+  url: string,
+  options?: RequestInit,
+  successMessage?: string
+): Promise<T | null> {
+  try {
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      const errorData = (await response.json()) as ApiErrorResponse;
+      showApiErrorToast(errorData);
+      return null;
+    }
+
+    const data = await response.json();
+
+    if (successMessage) {
+      showSuccessToast(successMessage);
+    }
+
+    return data as T;
+  } catch (error) {
+    showErrorToast(error, 'ネットワークエラーが発生しました');
+    return null;
+  }
+}

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  logDebug,
+  logInfo,
+  logWarn,
+  logError,
+  logApiRequest,
+  logAuth,
+  logSecurity,
+} from '@/lib/utils/logger';
+
+describe('Logger ユーティリティ', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('logDebug', () => {
+    it('開発環境でデバッグログを出力する', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+
+      logDebug('Test debug message');
+
+      expect(console.debug).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.debug as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.level).toBe('debug');
+      expect(logEntry.message).toBe('Test debug message');
+      expect(logEntry.timestamp).toBeDefined();
+
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('本番環境ではデバッグログを出力しない', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      logDebug('Test debug message');
+
+      expect(console.debug).not.toHaveBeenCalled();
+
+      process.env.NODE_ENV = originalEnv;
+    });
+  });
+
+  describe('logInfo', () => {
+    it('情報ログを出力する', () => {
+      logInfo('Test info message');
+
+      expect(console.info).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.level).toBe('info');
+      expect(logEntry.message).toBe('Test info message');
+    });
+
+    it('コンテキスト付きで情報ログを出力する', () => {
+      logInfo('Test info message', { context: 'TestContext', userId: 'user1' });
+
+      const logEntry = JSON.parse(
+        (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.context).toEqual({
+        context: 'TestContext',
+        userId: 'user1',
+      });
+    });
+  });
+
+  describe('logWarn', () => {
+    it('警告ログを出力する', () => {
+      logWarn('Test warning message');
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.warn as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.level).toBe('warn');
+      expect(logEntry.message).toBe('Test warning message');
+    });
+  });
+
+  describe('logError', () => {
+    it('エラーログを出力する', () => {
+      const error = new Error('Test error');
+      logError(error);
+
+      expect(console.error).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.error as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.level).toBe('error');
+      expect(logEntry.message).toBe('Test error');
+      expect(logEntry.error).toBeDefined();
+      expect(logEntry.error.name).toBe('Error');
+    });
+
+    it('コンテキスト付きでエラーログを出力する', () => {
+      const error = new Error('Test error');
+      logError(error, { context: 'APIHandler', method: 'POST' });
+
+      const logEntry = JSON.parse(
+        (console.error as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.context).toEqual({
+        context: 'APIHandler',
+        method: 'POST',
+      });
+    });
+
+    it('文字列エラーを処理できる', () => {
+      logError('String error message');
+
+      const logEntry = JSON.parse(
+        (console.error as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.message).toBe('String error message');
+    });
+  });
+
+  describe('logApiRequest', () => {
+    it('APIリクエストログを出力する', () => {
+      logApiRequest('GET', '/api/reports', 200, 150, 'user1');
+
+      expect(console.info).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.message).toBe('API GET /api/reports 200 150ms');
+      expect(logEntry.context).toMatchObject({
+        method: 'GET',
+        url: '/api/reports',
+        statusCode: 200,
+        durationMs: 150,
+        userId: 'user1',
+      });
+    });
+  });
+
+  describe('logAuth', () => {
+    it('認証ログを出力する', () => {
+      logAuth('login', 'user1');
+
+      expect(console.info).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.message).toBe('Auth: login');
+      expect(logEntry.context).toMatchObject({
+        action: 'login',
+        userId: 'user1',
+      });
+    });
+
+    it('追加コンテキスト付きで認証ログを出力する', () => {
+      logAuth('logout', 'user1', { ipAddress: '192.168.1.1' });
+
+      const logEntry = JSON.parse(
+        (console.info as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.context).toMatchObject({
+        action: 'logout',
+        userId: 'user1',
+        ipAddress: '192.168.1.1',
+      });
+    });
+  });
+
+  describe('logSecurity', () => {
+    it('セキュリティログを出力する', () => {
+      logSecurity('unauthorized_access', { ip: '192.168.1.1', path: '/admin' });
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      const logEntry = JSON.parse(
+        (console.warn as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      );
+      expect(logEntry.message).toBe('Security: unauthorized_access');
+      expect(logEntry.context).toMatchObject({
+        ip: '192.168.1.1',
+        path: '/admin',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- グローバルエラーハンドラー（`src/app/error.tsx`）の実装
- 404ページ（`src/app/not-found.tsx`）の実装
- APIエラーハンドラー（`withErrorHandler`）の実装
- エラートースト通知（sonner ライブラリ）の実装
- エラーログ記録機能（`logger.ts`）の実装

## 詳細
### 新規ファイル
- `src/app/error.tsx` - グローバルエラーバウンダリ
- `src/app/not-found.tsx` - 404ページ
- `src/components/ui/toast.tsx` - トースト通知コンポーネント
- `src/lib/utils/logger.ts` - エラーログユーティリティ
- `src/lib/utils/toast.ts` - トースト通知ヘルパー関数
- `tests/unit/utils/logger.test.ts` - ログユーティリティのテスト

### 変更ファイル
- `src/app/layout.tsx` - Toaster コンポーネントを追加
- `src/lib/utils/api.ts` - `withErrorHandler` ラッパー追加
- `src/lib/utils/index.ts` - 新規エクスポートを追加

## Test plan
- [x] 型チェック（`npm run type-check`）が通過
- [x] ESLint（`npm run lint`）が通過
- [x] 全テスト（260 テスト）が通過

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)