### PR TITLE
feat: Issue #53 日報一覧画面の期間整合性チェック実装

### DIFF
--- a/src/app/(dashboard)/reports/report-filters.test.tsx
+++ b/src/app/(dashboard)/reports/report-filters.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReportFilters } from './report-filters';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+const defaultProps = {
+  startDate: '',
+  endDate: '',
+  status: '',
+  salesId: '',
+  statusOptions: [
+    { value: '', label: 'すべて' },
+    { value: 'draft', label: '下書き' },
+    { value: 'submitted', label: '提出済み' },
+  ],
+  salesList: [
+    { value: '1', label: '山田太郎' },
+    { value: '2', label: '鈴木花子' },
+  ],
+  isManager: false,
+};
+
+describe('ReportFilters - 期間整合性チェック', () => {
+  it('開始日と終了日が正しい場合、エラーメッセージが表示されない', () => {
+    render(<ReportFilters {...defaultProps} />);
+
+    const startDateInput = screen.getByLabelText('期間（開始）');
+    const endDateInput = screen.getByLabelText('期間（終了）');
+
+    fireEvent.change(startDateInput, { target: { value: '2024-01-01' } });
+    fireEvent.change(endDateInput, { target: { value: '2024-01-31' } });
+
+    expect(
+      screen.queryByText('終了日は開始日以降の日付を指定してください。')
+    ).not.toBeInTheDocument();
+  });
+
+  it('開始日が終了日より後の場合、エラーメッセージが表示される', () => {
+    render(<ReportFilters {...defaultProps} />);
+
+    const startDateInput = screen.getByLabelText('期間（開始）');
+    const endDateInput = screen.getByLabelText('期間（終了）');
+
+    fireEvent.change(startDateInput, { target: { value: '2024-01-31' } });
+    fireEvent.change(endDateInput, { target: { value: '2024-01-01' } });
+
+    expect(
+      screen.getByText('終了日は開始日以降の日付を指定してください。')
+    ).toBeInTheDocument();
+  });
+
+  it('開始日と終了日が同じ場合、エラーメッセージが表示されない', () => {
+    render(<ReportFilters {...defaultProps} />);
+
+    const startDateInput = screen.getByLabelText('期間（開始）');
+    const endDateInput = screen.getByLabelText('期間（終了）');
+
+    fireEvent.change(startDateInput, { target: { value: '2024-01-15' } });
+    fireEvent.change(endDateInput, { target: { value: '2024-01-15' } });
+
+    expect(
+      screen.queryByText('終了日は開始日以降の日付を指定してください。')
+    ).not.toBeInTheDocument();
+  });
+
+  it('開始日のみ入力されている場合、エラーメッセージが表示されない', () => {
+    render(<ReportFilters {...defaultProps} />);
+
+    const startDateInput = screen.getByLabelText('期間（開始）');
+
+    fireEvent.change(startDateInput, { target: { value: '2024-01-01' } });
+
+    expect(
+      screen.queryByText('終了日は開始日以降の日付を指定してください。')
+    ).not.toBeInTheDocument();
+  });
+
+  it('終了日のみ入力されている場合、エラーメッセージが表示されない', () => {
+    render(<ReportFilters {...defaultProps} />);
+
+    const endDateInput = screen.getByLabelText('期間（終了）');
+
+    fireEvent.change(endDateInput, { target: { value: '2024-01-31' } });
+
+    expect(
+      screen.queryByText('終了日は開始日以降の日付を指定してください。')
+    ).not.toBeInTheDocument();
+  });
+
+  it('エラー状態で検索ボタンをクリックしても検索が実行されない', async () => {
+    render(<ReportFilters {...defaultProps} />);
+
+    const startDateInput = screen.getByLabelText('期間（開始）');
+    const endDateInput = screen.getByLabelText('期間（終了）');
+    const searchButton = screen.getByRole('button', { name: '検索' });
+
+    // 不正な期間を設定
+    fireEvent.change(startDateInput, { target: { value: '2024-01-31' } });
+    fireEvent.change(endDateInput, { target: { value: '2024-01-01' } });
+
+    // エラーメッセージが表示されていることを確認
+    expect(
+      screen.getByText('終了日は開始日以降の日付を指定してください。')
+    ).toBeInTheDocument();
+
+    // 検索ボタンをクリック
+    fireEvent.click(searchButton);
+
+    // エラーが表示されたままであることを確認（検索が実行されていない証拠）
+    expect(
+      screen.getByText('終了日は開始日以降の日付を指定してください。')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(dashboard)/reports/report-filters.tsx
+++ b/src/app/(dashboard)/reports/report-filters.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface FilterOption {
   value: string;
@@ -52,6 +53,14 @@ export function ReportFilters({
   const [status, setStatus] = useState(initialStatus);
   const [salesId, setSalesId] = useState(initialSalesId);
 
+  // 期間整合性チェック：開始日 ≦ 終了日
+  const dateError = useMemo(() => {
+    if (startDate && endDate && startDate > endDate) {
+      return '終了日は開始日以降の日付を指定してください。';
+    }
+    return null;
+  }, [startDate, endDate]);
+
   // YYYY/MM/DD形式をYYYY-MM-DD形式に変換
   function convertDisplayToInputDate(displayDate: string): string {
     return displayDate.replace(/\//g, '-');
@@ -59,6 +68,11 @@ export function ReportFilters({
 
   // 検索実行
   const handleSearch = useCallback(() => {
+    // 期間整合性エラーがある場合は検索を実行しない
+    if (dateError) {
+      return;
+    }
+
     const params = new URLSearchParams();
 
     if (startDate) {
@@ -77,7 +91,7 @@ export function ReportFilters({
     params.set('page', '1');
 
     router.push(`/reports?${params.toString()}`);
-  }, [startDate, endDate, status, salesId, router]);
+  }, [startDate, endDate, status, salesId, router, dateError]);
 
   // クリア
   const handleClear = useCallback(() => {
@@ -90,6 +104,13 @@ export function ReportFilters({
 
   return (
     <div className="space-y-4">
+      {/* 期間整合性エラーメッセージ */}
+      {dateError && (
+        <Alert variant="destructive">
+          <AlertDescription>{dateError}</AlertDescription>
+        </Alert>
+      )}
+
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {/* 期間（開始） */}
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- 日報一覧画面（S-003）に期間の整合性チェック（開始日 ≦ 終了日）を実装
- 不正な期間が入力された場合にエラーメッセージ（E-006）を表示
- エラー時は検索ボタン押下時も検索を実行しないよう制御
- 単体テスト6件を追加

## Test plan
- [x] 開始日と終了日が正しい場合、エラーメッセージが表示されないことを確認
- [x] 開始日が終了日より後の場合、エラーメッセージが表示されることを確認
- [x] 開始日と終了日が同じ場合、エラーメッセージが表示されないことを確認
- [x] 開始日または終了日のみ入力されている場合、エラーメッセージが表示されないことを確認
- [x] エラー状態で検索ボタンをクリックしても検索が実行されないことを確認

Closes #53

:robot: Generated with [Claude Code](https://claude.com/claude-code)