### PR TITLE
fix: Issue #55 日報一覧画面のソートインジケータa11y改善

### DIFF
--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -230,27 +230,23 @@ export default async function ReportsPage({
                 <Table aria-label="日報一覧">
                   <TableHeader>
                     <TableRow>
-                      <TableHead>
-                        <SortableHeader
-                          label="日付"
-                          field="reportDate"
-                          currentSort={sortBy}
-                          currentOrder={sortOrder}
-                          params={params}
-                        />
-                      </TableHead>
+                      <SortableTableHead
+                        label="日付"
+                        field="reportDate"
+                        currentSort={sortBy}
+                        currentOrder={sortOrder}
+                        params={params}
+                      />
                       {user.role === ROLES.MANAGER && (
                         <TableHead>営業担当者</TableHead>
                       )}
-                      <TableHead>
-                        <SortableHeader
-                          label="ステータス"
-                          field="status"
-                          currentSort={sortBy}
-                          currentOrder={sortOrder}
-                          params={params}
-                        />
-                      </TableHead>
+                      <SortableTableHead
+                        label="ステータス"
+                        field="status"
+                        currentSort={sortBy}
+                        currentOrder={sortOrder}
+                        params={params}
+                      />
                       <TableHead>訪問件数</TableHead>
                       <TableHead>操作</TableHead>
                     </TableRow>
@@ -322,9 +318,10 @@ export default async function ReportsPage({
 }
 
 /**
- * ソート可能なヘッダー
+ * ソート可能なテーブルヘッダー
+ * アクセシビリティ対応: aria-sort属性とスクリーンリーダー用テキストを含む
  */
-function SortableHeader({
+function SortableTableHead({
   label,
   field,
   currentSort,
@@ -346,16 +343,32 @@ function SortableHeader({
     page: '1',
   });
 
+  // aria-sort属性の値を決定
+  const ariaSortValue = isActive
+    ? currentOrder === 'desc'
+      ? 'descending'
+      : 'ascending'
+    : 'none';
+
   return (
-    <Link
-      href={`/reports?${queryString}`}
-      className="flex items-center gap-1 hover:text-foreground"
-    >
-      {label}
-      {isActive && (
-        <span className="text-xs">{currentOrder === 'desc' ? '▼' : '▲'}</span>
-      )}
-    </Link>
+    <TableHead aria-sort={ariaSortValue}>
+      <Link
+        href={`/reports?${queryString}`}
+        className="flex items-center gap-1 hover:text-foreground"
+      >
+        {label}
+        {isActive && (
+          <>
+            <span className="text-xs" aria-hidden="true">
+              {currentOrder === 'desc' ? '▼' : '▲'}
+            </span>
+            <span className="sr-only">
+              {currentOrder === 'desc' ? '（降順）' : '（昇順）'}
+            </span>
+          </>
+        )}
+      </Link>
+    </TableHead>
   );
 }
 


### PR DESCRIPTION
## Summary
- テーブルヘッダーに `aria-sort` 属性を追加（ascending/descending/none）
- ソートインジケータ（▼▲）に `aria-hidden="true"` を追加し、装飾的な文字をスクリーンリーダーから隠す
- スクリーンリーダー用の `sr-only` テキストを追加（「（降順）」「（昇順）」）

## Test plan
- [x] ESLint チェック通過
- [x] TypeScript 型チェック通過
- [x] 全 348 件のテスト通過
- [ ] スクリーンリーダーでソート状態が正しく読み上げられることを確認

Closes #55

🤖 Generated with [Claude Code](https://claude.ai/claude-code)